### PR TITLE
Make $prefix available for HTDOCSDIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,18 @@ AC_ARG_ENABLE(pkgonly,
                         [Skip all checking])])
 AC_SUBST(enable_pkgonly)
 
+# $prefix stores the value of the --prefix command line option, or
+# NONE if the option wasn't set.  In the case that it wasn't set, make
+# it be the default, so that we can use it to expand directories now.
+if test "x$prefix" = "xNONE"; then
+  prefix=$ac_default_prefix
+fi
+
+# and similarly for $exec_prefix
+if test "x$exec_prefix" = "xNONE"; then
+  exec_prefix=$prefix
+fi
+
 HTDOCSDIR=${prefix}/htdocs
 AC_ARG_WITH(htdocs-dir,AC_HELP_STRING([--with-htdocs-dir=DIR],[Where to install htdocs [PREFIX/htdocs]]), [HTDOCSDIR=$withval])
 AC_SUBST(HTDOCSDIR)


### PR DESCRIPTION
make install when neither --prefix nor --with-htdocs-dir were used was installing the htdocs into $dist_dir/htdocs/NONE/htdocs because $prefix is set to 'NONE' if the default is being used.  Code lifted from the Tor Project's configure.in to handle this.
