### PR TITLE
add "expect" parameter to Curl.pm

### DIFF
--- a/lib/Smokeping/probes/Curl.pm
+++ b/lib/Smokeping/probes/Curl.pm
@@ -330,7 +330,7 @@ sub pingone {
 
 			$self->$function(qq(WARNING: curl exited $why on $t->{addr}));
 		}
-	        push @times, $val if (defined $val and $expectOK);
+		push @times, $val if (defined $val and $expectOK);
 	}
 	
 	# carp("Got @times") if $self->debug;


### PR DESCRIPTION
Curl.pm now accepts an optional "expect" parameter contain text to look for in the response from the given URL.  If the parameter is specified, and the text is not found in the response, then the response will be treated as a failure, otherwise it is handled normally.  I use this to hit a status script to report on DB availability, environment configuration, etc
