### PR TITLE
DismanPing uses old data on SNMP error

### DIFF
--- a/lib/Smokeping/probes/DismanPing.pm
+++ b/lib/Smokeping/probes/DismanPing.pm
@@ -255,6 +255,11 @@ sub ping($) {
         my $addr = $t->{addr};
         my $idx  = idx($t);
         my $host = host($t);
+
+        # Empty out any RTTs from the last time around, so that on error we
+        # return "no result".
+        $self->{rtts}{ $t->{tree} } = {};
+
         # Delete any existing row.  Ignore error.
         #Smokeping::do_log("DismanPing deleting for $host $t->{vars}{menu}");
         my $ret =


### PR DESCRIPTION
I found that DismanPing uses old data on an SNMP error.  This change resets the rtts value at the start of a probe run, so that we don't return old data.
