### PR TITLE
Remove RRD max limit of 180 - so that the RRD can store values larger…

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -557,8 +557,8 @@ sub init_target_tree ($$$$) {
                         ($name.$s.".rrd", "--start",(time-1),"--step",$step,
                               "DS:uptime:GAUGE:".(2*$step).":0:U",
                               "DS:loss:GAUGE:".(2*$step).":0:".$pings,
-                              "DS:median:GAUGE:".(2*$step).":0:180",
-                              (map { "DS:ping${_}:GAUGE:".(2*$step).":0:180" }
+                              "DS:median:GAUGE:".(2*$step).":0:U",
+                              (map { "DS:ping${_}:GAUGE:".(2*$step).":0:U" }
                                                                           1..$pings),
                               (map { "RRA:".(join ":", @{$_}) } @{$cfg->{Database}{_table}} ));
                 if (not -f $name.$s.".rrd"){


### PR DESCRIPTION
… than 180 (e.g. for non-time data).

As discussed via email, I implemented this change in new RRDs so that we can store higher values (such as transfer rate in Mbps). It would be nice to be added in newer versions and it's minor enough not to add new bugs :)

Thanks