### PR TITLE
Call RRDs::fetch() with a zero length time period

### DIFF
--- a/lib/Smokeping/RRDtools.pm
+++ b/lib/Smokeping/RRDtools.pm
@@ -117,7 +117,7 @@ sub info2create {
 	my $cf = $info->{"rra[0].cf"};
 	die("$file: no RRAs found?") 
 		unless defined $cf;
-	my @fetch = RRDs::fetch($file, $cf);
+	my @fetch = RRDs::fetch($file, $cf, "-s 0", "-e 0");
 	$error = RRDs::error;
 	die("RRDs::fetch $file $cf: ERROR: $error") if $error;
 	my @ds = @{$fetch[2]};


### PR DESCRIPTION
The default fetch time period (1 day) can be very slow when the RRD
file is not in the filesystem cache.

The info2create function doesn't even use the data, it's just trying
to get the DS definition.

Specify a start and time of 0 so that no data is retrieved.

---
This makes the startup of smokeping.cgi 1-1.5 seconds faster for me.


Testing with a completely empty filesystem cache:

Before:
d762581b2c21b3926d4000450a6e2d2e3c1f53fef3339acb113f2223.rrd 146.113872528076ms
1e04ab36c4fcb81a106b8330df727bbe507cb76b2cb189b5deb31fd4.rrd 145.89786529541ms
dfb9aadbd545be0567e7c095601294ec19b1b29445e060eb07cf6950.rrd 395.570039749146ms
beec7a6b69d46a8fa31a911e9faa6be64decb11ae7b8cfcd3f4a41fa.rrd 210.230827331543ms
f4b1a9bb36c5d600b1e7b095dd6249462158b3cc349744e63ec99fcb.rrd 478.749990463257ms
08cdf4347074e08f8984c5c36fdaf789b0a62b49578781402231a68c.rrd 416.653156280518ms
2c4f65616ccced3fb26a8f0936c19011477a542da7fbb1c43778236e.rrd 1005.03706932068ms
e995124dc0bf8252b0cc9003e9dcfae43eecdd5d87088787b7d5c06b.rrd 525.73299407959ms
6c3e0c30b63320341bf1105681868403768b58591702e6869cbad7a6.rrd 462.279796600342ms
6ac106884d913983a0b7340c220692aa281464aff6739aa7b010de44.rrd 373.524188995361ms
733c07374b971c423e8e44c9060425860fb6d8b084136e75ead6a683.rrd 290.665149688721ms
c7b33271dda6bae863d3c5e4ed2d233b36fb8ecb58774bfa92f073e1.rrd 535.086870193481ms

After:
dfb9aadbd545be0567e7c095601294ec19b1b29445e060eb07cf6950.rrd 33.5471630096436ms
beec7a6b69d46a8fa31a911e9faa6be64decb11ae7b8cfcd3f4a41fa.rrd 33.7560176849365ms
6c3e0c30b63320341bf1105681868403768b58591702e6869cbad7a6.rrd 26.5040397644043ms
6ac106884d913983a0b7340c220692aa281464aff6739aa7b010de44.rrd 44.011116027832ms
f4b1a9bb36c5d600b1e7b095dd6249462158b3cc349744e63ec99fcb.rrd 44.6028709411621ms
08cdf4347074e08f8984c5c36fdaf789b0a62b49578781402231a68c.rrd 12.9008293151855ms
2c4f65616ccced3fb26a8f0936c19011477a542da7fbb1c43778236e.rrd 14.6379470825195ms
e995124dc0bf8252b0cc9003e9dcfae43eecdd5d87088787b7d5c06b.rrd 38.6829376220703ms
c7b33271dda6bae863d3c5e4ed2d233b36fb8ecb58774bfa92f073e1.rrd 82.0910930633545ms
733c07374b971c423e8e44c9060425860fb6d8b084136e75ead6a683.rrd 49.7238636016846ms
1e04ab36c4fcb81a106b8330df727bbe507cb76b2cb189b5deb31fd4.rrd 24.5110988616943ms
d762581b2c21b3926d4000450a6e2d2e3c1f53fef3339acb113f2223.rrd 36.2119674682617ms
