### PR TITLE
Display the master host "display_name" in the chart title

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1372,7 +1372,7 @@ sub get_detail ($$$$;$){
             my @lazy =();
             @lazy = ('--lazy') if $mode eq 's' and $lastheight{$s} and $lastheight{$s}{$start} and $lastheight{$s}{$start} == $max->{$s}{$start};
             my $timer_start = time();
-            my $from = $s ? " from $cfg->{Slaves}{$slave}{display_name}": "";
+            my $from = " from " . ($s ? $cfg->{Slaves}{$slave}{display_name}: $cfg->{General}{display_name} || hostname);
             my @task =
                ("${imgbase}${s}_${end}_${start}.png",
                @lazy,


### PR DESCRIPTION
When having multiple slaves, and in general, it is more clear if all chart titles contain an explicit "from XYZ" label where XYZ is either the master host name or the slave's name. This gives us an immediate insight for source of the ping check. Otherwise we need to remember that if "from" is missing, then this comes from the master host. This brings inconsistency in the user experience.

You can also consider the case when the CGI is behind a web reverse proxy. The user opens "https://web-proxy-server/smokeping.cgi?target=dc1.myhost" but the chart titles don't show a "from". In such a case, the user must know which is the actual master host which did the ping check. This could become even harder to remember if we have multiple instances of SmokePing.