### PR TITLE
Fix rendering multigraph with host ipv6 address

### DIFF
--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -223,6 +223,8 @@ sub get_multi_detail ($$$$;$){
             my $pings = $probe->_pings($tree);
 
             $label = sprintf("%-20s",$label);
+	    $label =~ s/:/\\:/g;
+
             push @colors, $medc;
             my $sdc = $medc;
             my $stddev = Smokeping::RRDhelpers::get_stddev($rrd,'median','AVERAGE',$realstart,$sigtime) || 0;


### PR DESCRIPTION
A host IPv6 adress in [RFC5952] representation contains colons which
should be escaped in legends since colons are part of rddtool syntax.

[RFC5952]: https://tools.ietf.org/html/rfc5952