### PR TITLE
Fix ipv6 in multigraph

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -910,6 +910,7 @@ sub get_overview ($$$$){
                     $label = "med RTT"
                 }
             };
+            $label =~ s/:/\\:/g;
 
             my $sdc = $medc;
             $sdc =~ s/^(......).*/${1}30/;

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -223,6 +223,8 @@ sub get_multi_detail ($$$$;$){
             my $pings = $probe->_pings($tree);
 
             $label = sprintf("%-20s",$label);
+	    $label =~ s/:/\\:/g;
+
             push @colors, $medc;
             my $sdc = $medc;
             my $stddev = Smokeping::RRDhelpers::get_stddev($rrd,'median','AVERAGE',$realstart,$sigtime) || 0;


### PR DESCRIPTION
A host IPv6 adress in [RFC5952] representation contains colons which
should be escaped in legends since colons are part of rddtool syntax.

[RFC5952]: https://tools.ietf.org/html/rfc5952