### PR TITLE
FPing: create new parameter to force using IPv4 or IPv6 fixes#95

### DIFF
--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -119,6 +119,7 @@ sub ping ($){
     # pinging nothing is pointless
     return unless @{$self->addresses};
     my @params = () ;
+    push @params, "-$self->{properties}{protocol}";
     push @params, "-b$self->{properties}{packetsize}" if $self->{properties}{packetsize};
     push @params, "-t" . int(1000 * $self->{properties}{timeout}) if $self->{properties}{timeout};
     push @params, "-i" . int(1000 * $self->{properties}{mininterval});
@@ -196,6 +197,12 @@ sub probevars {
 			_re => '(true|false)',
 			_example => 'true',
 			_doc => "Send an extra ping and then discarge the first answer since the first is bound to be an outliner.",
+
+		},
+		protocol => {
+			_re => '(4|6)',
+			_example => '4',
+			_doc => "Choose if the ping should use IPv4 or IPv6.",
 
 		},
 		usestdout => {

--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -202,6 +202,7 @@ sub probevars {
 		protocol => {
 			_re => '(4|6)',
 			_example => '4',
+			_default => '4',
 			_doc => "Choose if the ping should use IPv4 or IPv6.",
 
 		},

--- a/lib/Smokeping/probes/FPing6.pm
+++ b/lib/Smokeping/probes/FPing6.pm
@@ -47,6 +47,7 @@ sub probevars {
       my $h = $self->SUPER::probevars;
       $h->{binary}{_example} = "/usr/bin/fping6";
       $h->{protocol}{_example} = "6";
+      $h->{protocol}{_default} = "6";
       $h->{sourceaddress}{_re} = "[0-9A-Fa-f:.]+";
       $h->{sourceaddress}{_example} = "::1";
       return $h;

--- a/lib/Smokeping/probes/FPing6.pm
+++ b/lib/Smokeping/probes/FPing6.pm
@@ -46,6 +46,7 @@ sub probevars {
       my $self = shift;
       my $h = $self->SUPER::probevars;
       $h->{binary}{_example} = "/usr/bin/fping6";
+      $h->{protocol}{_example} = "6";
       $h->{sourceaddress}{_re} = "[0-9A-Fa-f:.]+";
       $h->{sourceaddress}{_example} = "::1";
       return $h;


### PR DESCRIPTION
Starting with FPing 3.16, the IPv6 functionality was merged in the main
binary and fping now respects the system-wide setting for address
resolution. This means that when we add a target that has both an A
record and a AAAA record, the probe tests the IPv6 address by default.

This breaks the expectation that the FPing probe tests IPv4 and that the
FPing6 probe checks IPv6.

To restore this, we can now add a parameter to the probes to force the
protocol version to be 4 or 6.