### PR TITLE
Remove unnecessary use Switch.

### DIFF
--- a/lib/Smokeping/probes/IRTT.pm
+++ b/lib/Smokeping/probes/IRTT.pm
@@ -21,7 +21,6 @@ use IPC::Open2 qw(open2);
 use JSON::PP qw(decode_json);
 use Path::Tiny qw(path);
 use Scalar::Util qw(looks_like_number);
-use Switch;
 use Symbol qw(gensym);
 use Time::HiRes qw(usleep gettimeofday tv_interval);
 


### PR DESCRIPTION
This was left over from the prior use of `switch`. Thanks for removing this dependency before.