### PR TITLE
Add require_zero_status to Curl.pm and update IRTT.pm email

### DIFF
--- a/lib/Smokeping/probes/Curl.pm
+++ b/lib/Smokeping/probes/Curl.pm
@@ -171,7 +171,17 @@ probe is treated as a failure
 DOC
 		_default => "",
 		_example => "Status: green",
-    },
+		},
+		require_zero_status => {
+			_doc => <<DOC,
+If this variable is set to 'yes', responses will only be counted if
+Curl's exit status is '0'. This is useful for reporting timeouts as
+losses rather than delayed responses.
+DOC
+			_default => "no",
+			_re => "(yes|no)",
+			_example => "yes",
+		},
 	});
 }
 
@@ -330,7 +340,9 @@ sub pingone {
 
 			$self->$function(qq(WARNING: curl exited $why on $t->{addr}));
 		}
-		push @times, $val if (defined $val and $expectOK);
+		if ($? == 0 or $t->{vars}{require_zero_status} eq "no") {
+			push @times, $val if (defined $val and $expectOK);
+		}
 	}
 	
 	# carp("Got @times") if $self->debug;

--- a/lib/Smokeping/probes/IRTT.pm
+++ b/lib/Smokeping/probes/IRTT.pm
@@ -54,7 +54,7 @@ set). Otherwise, there can be a deadlock while B<readfrom> targets wait for thei
 corresponding B<writeto> target to complete, which may never start.
 DOC
 		authors => <<'DOC',
-Pete Heist <pete@eventide.io>
+Pete Heist <pete@heistp.net>
 DOC
 	};
 }


### PR DESCRIPTION
This adds the `require_zero_status` parameter to Curl.pm. Personally I think require_zero_status = yes as a default is better, but I left it as no so as not to break existing installations.

Also updated my email address in IRTT.pm.