### PR TITLE
FPing: disable use of -4/-6 if binary is too old (closes: #146)

### DIFF
--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -83,6 +83,10 @@ sub new($$$)
             $self->{pingfactor} = 1000; # Gives us a good-guess default
             warn "### assuming you are using an fping copy reporting in milliseconds\n";
         }
+
+        # fping only has -4 and -6 switches starting with 3.16 and the binary refuses
+        # to run if the switches are passed in to older versions.
+        $self->{enable}{proto} = (`$binary -v 2>&1` =~ /Version (3.1[6-9]|[4-9])/);
     };
 
     return $self;
@@ -119,7 +123,7 @@ sub ping ($){
     # pinging nothing is pointless
     return unless @{$self->addresses};
     my @params = () ;
-    push @params, "-$self->{properties}{protocol}";
+    push @params, "-$self->{properties}{protocol}" if $self->{enable}{proto};
     push @params, "-b$self->{properties}{packetsize}" if $self->{properties}{packetsize};
     push @params, "-t" . int(1000 * $self->{properties}{timeout}) if $self->{properties}{timeout};
     push @params, "-i" . int(1000 * $self->{properties}{mininterval});


### PR DESCRIPTION
It would seem as though some distribution are still shipping versions of
fping that are too old for the new -4 and -6 switches. Users of Centos 7
and RHEL 7 reported having trouble with the new "protocol" parameter
because of this: EPEL7 currently ships fping 3.10.

If an old binary is found when starting up our FPing probe, we'll
disable use of the new switches in order to maintain functionality to
users with older versions of fping.