### PR TITLE
Default config sets max view as bigger than database

### DIFF
--- a/etc/config.dist.in
+++ b/etc/config.dist.in
@@ -95,7 +95,7 @@ unison_tolerance = 2
 "Last 3 Hours"    3h
 "Last 30 Hours"   30h
 "Last 10 Days"    10d
-"Last 400 Days"   400d
+"Last 360 Days"   360d
 
 #+ hierarchies
 #++ owner


### PR DESCRIPTION
This has been reported to the debian BTS by Dmitry Semyonov <linulin@gmail.com>

Default Database configuration file is defined so that only 360 days of
data could be stored:

max(steps * total) / (secs_in_a_day / step) =
144 * 720 / (86400 / 300) =
360

But Presentation configuration file defines the 4th graph as 400d, thus
making it always missing 40 oldest days of data.


The debian package has been using a patch to remove this inconsistency by changing the maximum view in the presentation section to 360 days instead of 400, but it was never reported here.

Original bug report here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=618851