### PR TITLE
Warn users if a probe binary exits with an error code (closes: #151)

### DIFF
--- a/lib/Smokeping/probes/DNS.pm
+++ b/lib/Smokeping/probes/DNS.pm
@@ -127,6 +127,8 @@ sub pingone ($){
 	    }
 	}
 	waitpid $pid,0;
+	my $rc = $?;
+	carp "$query returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
 	close $errh;
 	close $inh;
 	close $outh;

--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -165,6 +165,8 @@ sub ping ($){
         map { $self->{rtts}{$_} = [@times] } @{$self->{addrlookup}{$ip}} ;
     }
     waitpid $pid,0;
+    my $rc = $?;
+    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
     close $inh;
     close $outh;
     close $errh;

--- a/lib/Smokeping/probes/FPingContinuous.pm
+++ b/lib/Smokeping/probes/FPingContinuous.pm
@@ -185,6 +185,8 @@ sub run_pinger {
 	if($fh->eof) {
 	  $self->do_log("fping process exited - restarting");
 	  waitpid $fping_pid,0;
+	  my $rc = $?;
+	  carp "fping process returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
 	  close($fping_stdin);
 	  close($fping_stdout);
 	  close($fping_stderr);
@@ -240,6 +242,8 @@ sub run_pinger {
       } else {
 	$self->do_log("fping process exited - restarting");
 	waitpid $fping_pid,0;
+	my $rc = $?;
+	carp "fping process returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
 	close($fping_stdin);
 	close($fping_stdout);
 	close($fping_stderr);

--- a/lib/Smokeping/probes/IOSPing.pm
+++ b/lib/Smokeping/probes/IOSPing.pm
@@ -181,6 +181,8 @@ sub pingone ($$){
     @times = map {sprintf "%.10e", $_ / $self->{pingfactor}} sort {$a <=> $b} @times;
 
     waitpid $pid,0;
+    my $rc = $?;
+    carp join(" ",@args) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
     close $inh;
     close $outh;
 

--- a/lib/Smokeping/probes/NFSping.pm
+++ b/lib/Smokeping/probes/NFSping.pm
@@ -136,6 +136,8 @@ sub ping ($){
         map { $self->{rtts}{$_} = [@times] } @{$self->{addrlookup}{$ip}} ;
     }
     waitpid $pid,0;
+    my $rc = $?;
+    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
     close $inh;
     close $outh;
     close $errh;

--- a/lib/Smokeping/probes/Qstat.pm
+++ b/lib/Smokeping/probes/Qstat.pm
@@ -118,6 +118,8 @@ sub pinghost($$) {
         $time = $1;
     }
     waitpid $pid,0;
+    my $rc = $?;
+    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
     close $inh;
     close $outh;
     close $errh;

--- a/lib/Smokeping/probes/SSH.pm
+++ b/lib/Smokeping/probes/SSH.pm
@@ -98,6 +98,8 @@ sub pingone ($){
             }
         }
 	waitpid $pid,0;
+	my $rc = $?;
+	carp "$query returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
 	close $errh;
 	close $inh;
 	close $outh;

--- a/lib/Smokeping/probes/TCPPing.pm
+++ b/lib/Smokeping/probes/TCPPing.pm
@@ -158,6 +158,8 @@ sub pingone ($){
         @times = map {sprintf "%.10e", $_ / $self->{pingfactor}} sort {$a <=> $b} grep /^\d/, @times;
     }
     waitpid $pid,0;
+    my $rc = $?;
+    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
     close $inh;
     close $outh;
     close $errh;

--- a/lib/Smokeping/probes/TraceroutePing.pm
+++ b/lib/Smokeping/probes/TraceroutePing.pm
@@ -320,7 +320,8 @@ sub pingone ($) {
 	    $self->do_debug("stderr: $line");
 	}
 	waitpid $pid,0;
-	$self->do_debug("Exitstatus: " . $?) if ($? && !$killed);
+	my $rc = $?;
+	carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless ($rc == 0 || $killed);
 	close $f_stdin;
 	close $f_stdout;
 	close $f_stderr;


### PR DESCRIPTION
When a probe fails to run at all, it currently fails silently and the
only method that users can use to determine that the binary is failing
is to strace the smokeping protocol.

Users can already enable debug output in order to gain some insight
about what is going wrong, but they need to know first that something is
wrong.

TraceroutePing was already checking the return code, but was only
outputting debug information about the binary erroring out. This was
changed to "carp" instead so that probe binary errors are visible in
logs.

Some discrepancies:

 * FPingContinuous doesn't show the command that failed when it does
   since the arguments are hidden away in the run_fping() function. This
   shouldn't be too great an issue, since the command is output in debug,
   so users can see what's happening when they enable debug.

 * IRTT already handles the return code but dies out when return code is
   non-zero. Maybe this should be changed to use "carp" like other probes?