### PR TITLE
POD: add SEE ALSO sections to cross-reference doc pages (closes: #162)

### DIFF
--- a/bin/smokeinfo
+++ b/bin/smokeinfo
@@ -96,6 +96,10 @@ Show all nodes with '_wlan_' in the name
 
  smokeinfo --mode=regexp --filter=_wlan_ etc/config
 
+=head1 SEE ALSO
+
+L<smokeping(1)>
+
 =head1 COPYRIGHT
 
 Copyright (c) 2009 by OETIKER+PARTNER AG. All rights reserved.

--- a/bin/smokeping
+++ b/bin/smokeping
@@ -147,6 +147,13 @@ the SmokePing configuration file.
  use Smokeping;
  Smokeping::main("/home/oetiker/.smokeping/config");
 
+=head1 SEE ALSO
+
+L<smokeping_config(5)>, L<smokeping_examples(5)>, L<smokeping_cgi(1)>,
+L<tSmoke(1)>, L<smokeping_master_slave(7)>, L<smokeping_extend(7)>,
+L<smokeping_install(7)>, L<smokeping_upgrade(7)>,
+How to read the graphs https://oss.oetiker.ch/smokeping/doc/reading.en.html
+
 =head1 COPYRIGHT
 
 Copyright (c) 2002 by Tobias Oetiker. All right reserved.

--- a/bin/smokeping_cgi
+++ b/bin/smokeping_cgi
@@ -59,6 +59,11 @@ want to deal with.
 
 Adjust the paths in the script and you should be ready to go.
 
+=head1 SEE ALSO
+
+L<smokeping_config(5)>, L<smokeping(1)>, L<smokeping_install(7)>,
+L<smokeping_upgrade(7)>
+
 =head1 COPYRIGHT
 
 Copyright (c) 2011 by Tobias Oetiker. All right reserved.

--- a/bin/tSmoke
+++ b/bin/tSmoke
@@ -532,6 +532,10 @@ General section:
 
  tmail = /usr/local/smokeping/etc/tmail
 
+=head1 SEE ALSO
+
+L<smokeping(1)>, L<smokeping_config(5)>
+
 =head1 COPYRIGHT
 
 Copyright (c) 2003 by Dan McGinn-Combs. All right reserved.

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -3990,6 +3990,49 @@ POD
     $retval .= $parser->makepod;
     $retval .= <<POD;
 
+${e}head1 SEE ALSO
+
+L<smokeping(1)>,L<smokeping_master_slave(7)>,L<smokeping_cgi(1)>
+
+Matchers:
+
+L<Smokeping_matchers_Avgratio(3)>, L<Smokeping_matchers_CheckLatency(3)>,
+L<Smokeping_matchers_CheckLoss(3)>, L<Smokeping_matchers_ExpLoss(3)>,
+L<Smokeping_matchers_Median(3)>, L<Smokeping_matchers_Medratio(3)>,
+L<Smokeping_matchers_base(3)>
+
+Probes:
+
+L<Smokeping_probes_CiscoRTTMonDNS(3)>,
+L<Smokeping_probes_CiscoRTTMonEchoICMP(3)>,
+L<Smokeping_probes_CiscoRTTMonTcpConnect(3)>, L<Smokeping_probes_Curl(3)>,
+L<Smokeping_probes_DNS(3)>, L<Smokeping_probes_DismanPing(3)>,
+L<Smokeping_probes_EchoPing(3)>, L<Smokeping_probes_EchoPingChargen(3)>,
+L<Smokeping_probes_EchoPingDNS(3)>, L<Smokeping_probes_EchoPingDiscard(3)>,
+L<Smokeping_probes_EchoPingHttp(3)>, L<Smokeping_probes_EchoPingHttps(3)>,
+L<Smokeping_probes_EchoPingIcp(3)>, L<Smokeping_probes_EchoPingLDAP(3)>,
+L<Smokeping_probes_EchoPingPlugin(3)>, L<Smokeping_probes_EchoPingSmtp(3)>,
+L<Smokeping_probes_EchoPingWhois(3)>, L<Smokeping_probes_FPing(3)>,
+L<Smokeping_probes_FPing6(3)>, L<Smokeping_probes_FPingContinuous(3)>,
+L<Smokeping_probes_FTPtransfer(3)>, L<Smokeping_probes_IOSPing(3)>,
+L<Smokeping_probes_IRTT(3)>, L<Smokeping_probes_LDAP(3)>,
+L<Smokeping_probes_NFSping(3)>, L<Smokeping_probes_OpenSSHEOSPing(3)>,
+L<Smokeping_probes_OpenSSHJunOSPing(3)>, L<Smokeping_probes_Qstat(3)>,
+L<Smokeping_probes_Radius(3)>, L<Smokeping_probes_RemoteFPing(3)>,
+L<Smokeping_probes_SSH(3)>, L<Smokeping_probes_SendEmail(3)>,
+L<Smokeping_probes_SipSak(3)>, L<Smokeping_probes_TCPPing(3)>,
+L<Smokeping_probes_TacacsPlus(3)>, L<Smokeping_probes_TelnetIOSPing(3)>,
+L<Smokeping_probes_TelnetJunOSPing(3)>, L<Smokeping_probes_TraceroutePing(3)>,
+L<Smokeping_probes_WebProxyFilter(3)>, L<Smokeping_probes_base(3)>,
+L<Smokeping_probes_basefork(3)>, L<Smokeping_probes_basevars(3)>,
+L<Smokeping_probes_passwordchecker(3)>, L<Smokeping_probes_skel(3)>
+
+Sorters:
+
+L<Smokeping_sorters_Loss(3)>, L<Smokeping_sorters_Max(3)>,
+L<Smokeping_sorters_Median(3)>, L<Smokeping_sorters_StdDev(3)>,
+L<Smokeping_sorters_base(3)>
+
 ${e}head1 COPYRIGHT
 
 Copyright (c) 2001-2007 by Tobias Oetiker. All right reserved.
@@ -4741,6 +4784,10 @@ figure heads allowing to hardcode some pathnames.
 
 If you feel like documenting what is happening within this library you are
 most welcome todo so.
+
+=head1 SEE ALSO
+
+L<smokeping_extend(7)>, L<smokeping(1)>, L<smokeping_config(5)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Francesco Potortì <Potorti@isti.cnr.it> requested in debian bug report
740852 that some cross-reference links be added do documentation pages.

This should make it easier for users to find more information about how
the software is configured and how it can be extended.