### PR TITLE
Add relative time parser on JS side for cropper

### DIFF
--- a/htdocs/js/smokeping.js
+++ b/htdocs/js/smokeping.js
@@ -15,6 +15,32 @@ function urlObjGetUrlBase() {
    return this.urlBase;
 }
 
+function parseRelativeTime(currTime) {
+    var unit = '';
+    var offset = 0;
+    var sign = -1;
+    var table = {
+        s : 1,        // 1
+        m : 60,       // s * 60
+        h : 3600,     // m * 60
+        d : 86400,    // h * 24
+        w : 604800,    // d * 7
+        mo : 2592000, // d * 30
+        y : 31536000, // d * 365
+    };
+    var regexStr = currTime.match(/[+\-]|[^a-z]+|[a-zA-Z]+/gi);
+    if (regexStr[0] == '+')
+        sign = 1;
+    for (i=1; i< regexStr.length; i=i+2) {
+        unit = regexStr[i+1].slice(0,1);
+        if (regexStr[i+1].slice(0,2) == 'mo' || (regexStr[i+1] == 'm' && Math.abs(regexStr[i]) <= 5))
+            unit = 'mo';
+        offset += regexStr[i]*table[unit];
+
+    }
+    offset = offset*sign;
+    return Math.floor(Date.now()/1000) + offset;
+}
 
 // example with minimum dimensions
 var myCropper;
@@ -47,12 +73,16 @@ function changeRRDImage(coords,dimensions){
     var RRDImgUsable = RRDImgWidth - RRDRight - RRDLeft;  
     var form = $('range_form');   
     
-    if (StartEpoch == 0)
+    if (StartEpoch == 0) {
         StartEpoch = +$F('epoch_start');
-   
-    if (EndEpoch  == 0)
+        if (isNaN(StartEpoch))
+            StartEpoch = parseRelativeTime($F('epoch_start'));
+    }
+    if (EndEpoch  == 0) {
         EndEpoch = +$F('epoch_end');
-
+        if (isNaN(EndEpoch))
+            EndEpoch = parseRelativeTime($F('epoch_end'));
+    }
     var DivEpoch = EndEpoch - StartEpoch; 
 
     var Target = $F('target');


### PR DESCRIPTION
@oetiker please review and merge. Fixes the issue shown in #177 - it adds a case to handle when start and end epoch are NaN(due to relative time ex: -1h) - then parses them. Other input checking is not needed because an error will be thrown by RRDtool. I accounted for when "m" is 5 or under it references months and 6 and over it references minutes. A loop was added to parse multiple relative times chained together that are successfully handled by RRDTool ex: -1d1h.