### PR TITLE
Fix reloading of Slave configuration

### DIFF
--- a/lib/Smokeping/Slave.pm
+++ b/lib/Smokeping/Slave.pm
@@ -107,9 +107,16 @@ sub submit_results {
             warn "WARNING $slave_cfg->{master_url} sent data with wrong key";
             return undef;
         }
+        # Safe seems to reset SIG on at least FreeBSD, causing slave to crash after first reload
+        # since all handlers are gone.
+        my %sig_backup = %SIG;
+
         my $zone = new Safe;
         # $zone->permit_only(???); #input welcome as to good settings
         my $config = $zone->reval($data);
+
+        %SIG = %sig_backup;
+
         if ($@){
             warn "WARNING evaluating new config from server failed: $@ --\n$data";
         } elsif (defined $config and ref $config eq 'HASH'){


### PR DESCRIPTION
On at least perl 5.28.2 in FreeBSD 11.3, Safe seems to clear %SIG,
removing all our signal handlers. This resulted in a crashed main
process, just as described in #44.

This is the first time I'm using a master/slave setup, so I do not know if this was the problem all along in #44 or if it is something FreeBSD specific, or some other regression. 

Observed behaviour was that initial fetch from master succeeded and ran fine, but as soon as main process received a HUP signal, it fetched new config and then exited (without cleaning up previous probe processes).

By adding debug logging, I managed to find first that it died just after the FPing constructor was called, after running the [backtick eval](https://github.com/oetiker/SmokePing/blob/master/lib/Smokeping/probes/FPing.pm#L69).
After commenting out the stdout/stderr redirect during daemonization, I noticed it wrote out a  `Signal CHLD received, but no signal handler set.` at the same time it died.
I commented out the FPing time detection stuff to see if that was the only problem, and it got further. A bit, but still crashed when waiting for the forked child processes to die, in the `sleep 1` in the loop it simply died (not sure if it logged `Signal CHLD received ...`).

A this point I started looking at what %SIG held, and noticed that somewhere during reload, it was cleared.

More debug logs added, and I finally ended up in this piece of code.
With this patch, HUP and reloads works perfectly fine on at least this machine, with perl 5.28.2 on FreeBSD 11.3.
Not sure if this is a problem on other platforms or not, #44 is quite old and talks both about FreeBSD and systemd..