### PR TITLE
FPing: Make protocol parameter optional

### DIFF
--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -123,7 +123,7 @@ sub ping ($){
     # pinging nothing is pointless
     return unless @{$self->addresses};
     my @params = () ;
-    push @params, "-$self->{properties}{protocol}" if $self->{enable}{proto};
+    push @params, "-$self->{properties}{protocol}" if $self->{properties}{protocol} and $self->{enable}{proto};
     push @params, "-b$self->{properties}{packetsize}" if $self->{properties}{packetsize};
     push @params, "-t" . int(1000 * $self->{properties}{timeout}) if $self->{properties}{timeout};
     push @params, "-i" . int(1000 * $self->{properties}{mininterval});
@@ -208,7 +208,6 @@ sub probevars {
 		protocol => {
 			_re => '(4|6)',
 			_example => '4',
-			_default => '4',
 			_doc => "Choose if the ping should use IPv4 or IPv6.",
 
 		},


### PR DESCRIPTION
This allows using a single FPing probe definition for both IPv4 and IPv6
targets.
Dual stack targets are of course supported as well. The actual protocol used
will depend on what getaddrinfo() returns, i.e. what is configured in
/etc/gai.conf on glibc/Linux.

Closes #204