### PR TITLE
Fix falling parameter in ExpLoss Matcher

### DIFF
--- a/lib/Smokeping/matchers/ExpLoss.pm
+++ b/lib/Smokeping/matchers/ExpLoss.pm
@@ -105,10 +105,7 @@ sub Test($$) {
     my $alfa = 1-0.01**(1/$hist);
 
     my $rising = $self->{param}{rising};
-    my $falling = $rising;
-    if(defined $self->{param}{falling}) {
-        $falling = $self->{param}{falling};
-    }
+    my $falling = $self->{param}{falling} // $rising;
 
     my $result = 0; # initialize the filter as zero;
     my $loss;

--- a/lib/Smokeping/matchers/ExpLoss.pm
+++ b/lib/Smokeping/matchers/ExpLoss.pm
@@ -105,7 +105,10 @@ sub Test($$) {
     my $alfa = 1-0.01**(1/$hist);
 
     my $rising = $self->{param}{rising};
-    my $falling = (defined $self->{param}{falling} || $rising);
+    my $falling = $rising;
+    if(defined $self->{param}{falling}) {
+        $falling = $self->{param}{falling};
+    }
 
     my $result = 0; # initialize the filter as zero;
     my $loss;


### PR DESCRIPTION
The ExpLoss Matcher does not work properly because the $falling variable contains the result of a boolean expression ('1') instead of the actual value passed into the matcher from the configuration.