### PR TITLE
Update Smokeping.pm

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -787,6 +787,7 @@ sub fill_template ($$;$){
 
 sub exp2seconds ($) {
     my $x = shift;
+    $x =~/(\d+)s/ && return $1;
     $x =~/(\d+)m/ && return $1*60;
     $x =~/(\d+)h/ && return $1*60*60;
     $x =~/(\d+)d/ && return $1*60*60*24;


### PR DESCRIPTION
When using a "seconds" value in in etc/config for graph details, e.g. 

"Last 30 Hours"   107999s

, then date conversion fails for the link to click / zoom into that graph. Error message:

RRDtool did not understand your input: start time: did you really mean month 107999?.

bad URL generated:

smokeping.fcgi?displaymode=n;start=107999s;end=now;target=XXX

Fix: get rid of "s" suffix before handing over to strftime().