### PR TITLE
Add probe target to detailed graph's title.

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1385,7 +1385,7 @@ sub get_detail ($$$$;$){
             my $timer_start = time();
             my $title = "";
             if ($cfg->{Presentation}{htmltitle} ne 'yes') {
-                $title = "$desc from " . ($s ? $cfg->{Slaves}{$slave}{display_name}: $cfg->{General}{display_name} || hostname);
+                $title = "$desc from " . ($s ? $cfg->{Slaves}{$slave}{display_name}: $cfg->{General}{display_name} || hostname) . " to $phys_tree->{title}";
             }
             my @task =
                ("${imgbase}${s}_${end}_${start}.png",


### PR DESCRIPTION
The detailed graphs are missing the arguably most important information about them: Who or what is the target of our probes. 

When the graphs are taken out of the context of the web interface, there is nothing on the graph telling you what target you are probing. This PR adds the probe target to the title of the detailed graphs when `htmltitle=no` is set.
![Screenshot_2021-05-14 SmokePing Latency Page for Google DNS (8 8 8 8)](https://user-images.githubusercontent.com/72616153/118557988-4c533200-b766-11eb-8e78-b9666e7f20f8.png)

I *did not* add the target when `htmltitle=yes` is set in the config, since you only ever see the html titles in the context of the web interface where you already have a giant header basically screaming the target at you.


