### PR TITLE
Add probe description to overview graphs.

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1433,7 +1433,7 @@ sub get_detail ($$$$;$){
                  ()),
                  'HRULE:0#000000',
                  "COMMENT:probe${BS}:       $pings $ProbeDesc every ${step}s",
-                 'COMMENT:end\: '.$date.'\j' );
+                 "COMMENT:$date\\j");
 #       do_log ("***** begin task ***** <br />");
 #       do_log (@task);
 #       do_log ("***** end task ***** <br />");

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -876,6 +876,7 @@ sub get_overview ($$$$){
         my $i = 0;
         my @colors = split /\s+/, $cfg->{Presentation}{multihost}{colors};
         my $ProbeUnit = $probe->ProbeUnit();
+        my $ProbeDesc = $probe->ProbeDesc();
         for my $slave (@slaves){
             $i++;
             my $rrd;
@@ -893,11 +894,23 @@ sub get_overview ($$$$){
                 $probe = $probes->{$tree->{probe}};
                 $pings = $probe->_pings($tree);
                 $label = $tree->{menu};
-                # if there are multiple units ... lets say so ... 
-                if ($ProbeUnit ne $probe->ProbeUnit()){
-                    $ProbeUnit = 'var units';
+
+                # if there are multiple probes ... lets say so ...
+                my $XProbeDesc = $probe->ProbeDesc();
+                if (not $ProbeDesc or $ProbeDesc eq $XProbeDesc){
+                    $ProbeDesc = $XProbeDesc;
                 }
-                
+                else {
+                    $ProbeDesc = "various probes";
+                }
+                my $XProbeUnit = $probe->ProbeUnit();
+                if (not $ProbeUnit or $ProbeUnit eq $XProbeUnit){
+                    $ProbeUnit = $XProbeUnit;
+                }
+                else {
+                    $ProbeUnit = "various units";
+                }
+
                 if ($real_slave){
                     $label .= "<".  $cfg->{Slaves}{$real_slave}{display_name};
                 }
@@ -957,7 +970,8 @@ sub get_overview ($$$$){
            '--rigid',
            '--lower-limit','0',
            @G,
-           "COMMENT:$date\\r");
+           "COMMENT:$ProbeDesc",
+           "COMMENT:$date\\j");
         my $ERROR = RRDs::error();
         $page .= "<div class=\"panel\">";
         $page .= "<div class=\"panel-heading\"><h2>".$phys_tree->{title}."</h2></div>"

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -271,7 +271,7 @@ sub get_multi_detail ($$$$;$){
                Smokeping::Graphs::get_colors($cfg),
                 @G,
                "COMMENT:$ProbeDesc",
-               'COMMENT:end\: '.$date.'\j';
+               "COMMENT:$date\\j";
 
         my $graphret;
         ($graphret,$xs,$ys) = RRDs::graph @task;


### PR DESCRIPTION
Title says everything. The overview graphs were missing a comment about what probes they display. I basically used the same code as was already in *lib/Smokeping/Graphs.pm* for the detailed multihost graphs and added it to the overview graphs.
![Screenshot_2021-05-14 SmokePing Latency Page for Domain name system](https://user-images.githubusercontent.com/72616153/118553693-f334cf80-b760-11eb-98ab-de73802ec578.png)

I also removed the `end:` before the timestamp, since I don't think it serves any purpose other than stating the obvious.
