### PR TITLE
New design for loss colors in detailed graphs.

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1261,9 +1261,9 @@ sub get_detail ($$$$;$){
         %lc =  (0         => ['0',                                  '#26ff00'],
                 $per01    => [display_range(1         , $per01),    '#00b8ff'],
                 $per05    => [display_range($per01 + 1, $per05),    '#0059ff'],
-                $per10    => [display_range($per05 + 1, $per10),    '#5e00ff'],
-                $per25    => [display_range($per10 + 1, $per25),    '#7e00ff'],
-                $per50    => [display_range($per25 + 1, $per50),    '#dd00ff'],
+                $per10    => [display_range($per05 + 1, $per10),    '#7e00ff'],
+                $per25    => [display_range($per10 + 1, $per25),    '#ff00ff'],
+                $per50    => [display_range($per25 + 1, $per50),    '#ff5500'],
                 $p-1      => [display_range($per50 + 1, ($p-1)),    '#ff0000'],
                 $p        => ["$p/$p",                              '#a00000']
                 );


### PR DESCRIPTION
The current design for loss colors has, in my opinion, a few deficiencies. I know you can customize these to your own liking in the config, but those settings will be used for *all* graphs regardless of the actual number of pings. When deploying several probes with different number of pings it is necessary to make your config work for all of them *at the same time*. This is not ideal and may not even be feasible in some cases.

So I went out and did some changes to the default settings because they are able to adapt to different number of pings and create a color loss description individual to each graph. Thought I might as well share them here.

Here are the issues I have with the current defaults and what I changed:
1. The lower values for loss are hardcoded to 1, 2, 3, and 4. 
Those may be good values for the default number of pings of 20, however, when you up the number of pings the current values for loss colors get less useful. When using 60 pings for your probe, you basically get no granularity past ~7% packet loss. You cannot tell whether you are losing 10% or 45% because they will get the same color right now. It gets even worse when using even larger number of pings.
This PR will use calculated values of 1%, 5%, 10%, 25%, 50%, and 100% of the number of pings.
2. Currently only the upper bound is shown for each color, which I think is a weird choice. It also repeats the total number of pings every single time, even though the number of pings is already displayed in the comment together with the probe description. When I saw a graph showing red it took me longer than I'm willing to admit to figure out that I wasn't losing everything except exactly one packet.
This PR will display ranges in the form of `x-y`, where `x` is the lower boundary and `y` the upper boundary.
3. Dark blue and dark purple are damn near indistinguishable. Especially when they are drawn against a dark grey to black background. Even when they are right next to each other they become hard to tell apart without `loss_background=yes`. 
This PR ditches the blue-ish purple, brightens the pink a little bit and introduces orange as a replacement.



---
Current:
![image](https://user-images.githubusercontent.com/72616153/118560022-23806c00-b769-11eb-92da-f2d5e18f7265.png)

---

New:
![Screenshot_2021-05-15 SmokePing Latency Page for Cloudflare (1 1 1 1)](https://user-images.githubusercontent.com/72616153/118560084-3dba4a00-b769-11eb-8c2f-26f76e6ad8d2.png)
![Screenshot_2021-05-15 SmokePing Latency Page for Cloudflare (1 0 0 1)](https://user-images.githubusercontent.com/72616153/118560097-401ca400-b769-11eb-85f8-1813908a2104.png)
![Screenshot_2021-05-15 SmokePing Latency Page for Quad9 (9 9 9 9)](https://user-images.githubusercontent.com/72616153/118560103-41e66780-b769-11eb-94b3-006ff14661b2.png)
![Screenshot_2021-05-15 SmokePing Latency Page for Google DNS (8 8 8 8)](https://user-images.githubusercontent.com/72616153/118560089-3eeb7700-b769-11eb-845b-366c8800f3fc.png)