### PR TITLE
Make FPing less verbose and remove interface restriction

### DIFF
--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -166,8 +166,16 @@ sub ping ($){
         map { $self->{rtts}{$_} = [@times] } @{$self->{addrlookup}{$ip}} ;
     }
     waitpid $pid,0;
+    # Exit status (of fping) is
+    #   0 if all the hosts are reachable,
+    #   1 if some hosts were unreachable,
+    #   2 if any IP addresses were not found,
+    #   3 for invalid command line arguments, and
+    #   4 for a system call failure.
+    # Don't log 0 or 1 as an unreachable host is not unexpected for a monitoring software
     my $rc = $?;
-    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $rc == 0;
+    my $status = $rc >> 8;
+    carp join(" ",@cmd) . " returned with exit code $rc. run with debug enabled to get more information" unless $status == 0 or $status == 1;
     close $inh;
     close $outh;
     close $errh;
@@ -269,7 +277,6 @@ a copy on www.smokeping.org/pub.
 DOC
 		},
 		interface => {
-			_re => '[a-zA-Z0-9]+',
 			_example => 'eth0',
 			_doc => "The name of the network interface to perform the ping on.",
 		},


### PR DESCRIPTION
This change disables the error logging when fping exits with a code of 1 and this fixes #283.

Fping exits with 1 when at least one host is not reachable. This is expected to happen in a monitoring software and we would just spam the log output if we log every failed probe. Alerts are responsible to notify about this.

We still log exit codes >=2, which are actual problems an operator should be aware of.
