### PR TITLE
Remove --insecure from curl call

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+ - remove --insecure from curl (wget does not have it!) in configure.ac @Gunni
+
 2021-08-13 08:12:06 +0200 Tobias Oetiker <tobi@oetiker.ch>
 
  - release 2.8.2

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_PATH_PROG(WGET, wget, no)
 URL_CAT="neither curl nor wget found"
 
 if test -x "$CURL"; then
-    URL_CAT="$CURL --location --insecure"
+    URL_CAT="$CURL --location"
 else
     if test -x "$WGET"; then
         URL_CAT="$WGET -O -"


### PR DESCRIPTION
`wget` doesn't use insecure, why should `curl` be any different.

Why even use insecure, ever?