### PR TITLE
Fix issue caused by curl 7.74 and later shortening default help #266

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
  - remove --insecure from curl (wget does not have it!) in configure.ac @Gunni
+ - add fix for curl feature checking introduced in curl 7.74 and later @matellis
 
 2021-08-13 08:12:06 +0200 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/lib/Smokeping/probes/Curl.pm
+++ b/lib/Smokeping/probes/Curl.pm
@@ -220,7 +220,7 @@ sub test_usage {
 
 	my $arghashref = $self->features;
 	my %arghash = %$arghashref;
-        my $curl_man = `$bin --help`;
+        my $curl_man = `$bin --help all`;
         
 	for my $feature (keys %arghash) {
 		next if $curl_man =~ /\Q$arghash{$feature}/;


### PR DESCRIPTION
This fixes issue #266 which effectively breaks curl probes on any distro using a newer version of curl, suspect 7.74 and later.