### PR TITLE
Enhance graphborders feature

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
  - remove --insecure from curl (wget does not have it!) in configure.ac @Gunni
  - add fix for curl feature checking introduced in curl 7.74 and later @matellis
+ - enhancement to remove more borders with graphborders set to no @matellis
 
 2021-08-13 08:12:06 +0200 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/htdocs/css/smokeping-screen.css
+++ b/htdocs/css/smokeping-screen.css
@@ -181,12 +181,15 @@ a#menu-button:hover {
 	display: inline-block;
 }
 
+.main .panel, .main .panel-no-border {
+	margin: 5px;
+	display: inline-block;
+}
+
 .main .panel {
 	border: 1px solid #d4d4d4;
 	box-shadow: 0 2px 1px -1px rgba(0,0,0,0.1);
 	background: #fff;
-	margin: 5px;
-	display: inline-block;
 }
 
 .main .panel-heading {
@@ -195,7 +198,10 @@ a#menu-button:hover {
 	box-shadow: inset 0 0 1px 1px #fff;
 }
 
-.main .panel-heading h2 {
+.panel-heading-no-border {
+}
+
+.main .panel-heading h2, .main .panel-heading-no-border h2 {
 	margin: 0;
 	padding-left: 10px;
 	line-height: 30px;

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -297,6 +297,22 @@ sub sendsnpp ($$){
     }
 }
 
+sub panel_class {
+    if ($cfg->{Presentation}{graphborders} eq 'no') {
+        return 'panel-no-border';
+    } else {
+        return 'panel';
+    }
+}
+
+sub panel_heading_class {
+    if ($cfg->{Presentation}{graphborders} eq 'no') {
+        return 'panel-heading-no-border';
+    } else {
+        return 'panel-heading';
+    }
+}
+
 sub min ($$) {
         my ($a, $b) = @_;
         return $a < $b ? $a : $b;
@@ -998,8 +1014,8 @@ sub get_overview ($$$$){
            "COMMENT:$ProbeDesc",
            "COMMENT:$date\\j");
         my $ERROR = RRDs::error();
-        $page .= "<div class=\"panel\">";
-        $page .= "<div class=\"panel-heading\"><h2>".$phys_tree->{title}."</h2></div>"
+        $page .= "<div class=\"".panel_class()."\">";
+        $page .= "<div class=\"".panel_heading_class()."\"><h2>".$phys_tree->{title}."</h2></div>"
             if $cfg->{Presentation}{htmltitle} eq 'yes';
         $page .= "<div class=\"panel-body\">";
         if (defined $ERROR) {
@@ -1493,10 +1509,10 @@ sub get_detail ($$$$;$){
              return undef;
         } 
         elsif ($mode eq 'n'){ # navigator mode
-           $page .= "<div class=\"panel\">";
+           $page .= "<div class=\"".panel_class()."\">";
            if ($cfg->{Presentation}{htmltitle} eq 'yes') {
                 # TODO we generate this above to, maybe share code or store variable ?
-                $page .= "<div class=\"panel-heading\"><h2>$desc</h2></div>";
+                $page .= "<div class=\"".panel_heading_class()."\"><h2>$desc</h2></div>";
             }
            $page .= "<div class=\"panel-body\">";
            $page .= qq|<IMG alt="" id="zoom" width="$xs{''}" height="$ys{''}" SRC="${imghref}_${end}_${start}.png">| ;
@@ -1521,13 +1537,13 @@ sub get_detail ($$$$;$){
             $t =~ s/$xssBadRx/_/g; 
             for my $slave (@slaves){
                 my $s = $slave ? "~$slave" : "";
-                $page .= "<div class=\"panel\">";
+                $page .= "<div class=\"".panel_class()."\">";
 #           $page .= (time-$timer_start)."<br/>";
 #           $page .= join " ",map {"'$_'"} @task;
                 if ($cfg->{Presentation}{htmltitle} eq 'yes') {
                     # TODO we generate this above to, maybe share code or store variable ?
                     my $title = "$desc from " . ($s ? $cfg->{Slaves}{$slave}{display_name}: $cfg->{General}{display_name} || hostname);
-                    $page .= "<div class=\"panel-heading\"><h2>$title</h2></div>";
+                    $page .= "<div class=\"".panel_heading_class()."\"><h2>$title</h2></div>";
                 }
                 $page .= "<div class=\"panel-body\">";
                 $page .= ( qq{<a href="}.cgiurl($q,$cfg)."?".hierarchy($q).qq{displaymode=n;start=$startstr;end=now;}."target=".$t.$s.'">'
@@ -1563,8 +1579,8 @@ sub get_charts ($$$){
     }
     if (not defined $open->[1]){
         for my $chart ( keys %charts ){
-            $page .= "<div class=\"panel\">";
-            $page .= "<div class=\"panel-heading\"><h2>$cfg->{Presentation}{charts}{$chart}{title}</h2></div>\n";
+            $page .= "<div class=\"".panel_class()."\">";
+            $page .= "<div class=\"".panel_heading_class()."\"><h2>$cfg->{Presentation}{charts}{$chart}{title}</h2></div>\n";
             if (not defined $charts{$chart}[0]){
                 $page .= "<p>No targets returned by the sorter.</p>"
             } else {
@@ -1597,7 +1613,7 @@ sub get_charts ($$$){
                 last unless ref $tree->{$host} eq 'HASH';
                 $tree = $tree->{$host};
             }       
-            $page .= "<div class=\"panel\">";
+            $page .= "<div class=\"".panel_class()."\">";
             $page .= "<div class=\"panel-heading\"><h2>$rank."; 
             $page .= " ".sprintf($cfg->{Presentation}{charts}{$chart}{format},$chartentry->{value})
                 if ($cfg->{Presentation}{charts}{$chart}{format});


### PR DESCRIPTION
This change removes the CSS formatting around each HTML panel when `graphborders` is set to `no` in `Presentation` config file.