### PR TITLE
Ability to configure graph background and text colors via configuration files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
  - remove --insecure from curl (wget does not have it!) in configure.ac @Gunni
  - add fix for curl feature checking introduced in curl 7.74 and later @matellis
+ - enhancement to extend color handling, making dark templates easier to do @matellis
 
 2021-08-13 08:12:06 +0200 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -3226,7 +3226,7 @@ Defines how the SmokePing data should be presented.
 DOC
           _sections => [ qw(overview detail charts multihost hierarchies) ],
           _mandatory => [ qw(overview template detail) ],
-          _vars      => [ qw (template charset htmltitle graphborders) ],
+          _vars      => [ qw (template charset htmltitle graphborders colortext colorbackground colorborder) ],
           template   => 
          {
           _doc => <<DOC,
@@ -3265,6 +3265,28 @@ will be transparent.
 DOC
            _re  => '(yes|no)',
            _re_error =>"this must either be 'yes' or 'no'",
+         },
+         colortext => {
+           _doc => <<DOC,
+DOC
+           _re => '[0-9a-f]{6}',
+           _re_error => 'use rrggbb for color',
+         },
+         colorborder => {
+           _doc => <<DOC,
+By default, SmokePing will render the border gray, which may be overridden
+here with your own RGB value
+DOC
+           _re => '[0-9a-f]{6}',
+           _re_error => 'use rrggbb for color',
+         },
+         colorbackground => {
+           _doc => <<DOC,
+By default, SmokePing will render the background light gray, which may be
+overridden here with your own RGB value
+DOC
+           _re => '[0-9a-f]{6}',
+           _re_error => 'use rrggbb for color',
          },
          charts => {
            _doc => <<DOC,

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -24,15 +24,39 @@ the graphs shown in the overview page, except for the size.
 
 sub get_colors ($){
     my $cfg = shift;
+    my @colorList = ();
+    my $colorText = $cfg->{Presentation}{colortext};
+    my $colorBorder = $cfg->{Presentation}{colorborder};
+    my $colorBackground = $cfg->{Presentation}{colorbackground};
 
-    if ($cfg->{Presentation}{graphborders} eq 'no') {
+    # If graphborders set to no, and no color override, then return default colors as before
+    if (($cfg->{Presentation}{graphborders} eq 'no') && !($colorText||$colorBorder||$colorBackground)) {
         return '--border', '0',
                 '--color', 'BACK#ffffff00',
                 '--color', 'CANVAS#ffffff00';
-    }
+    };
 
-    # Use rrdtool defaults
-    return;
+    # If there are any overrides, use them
+    if ($cfg->{Presentation}{graphborders} eq 'no') {
+        push(@colorList, '--border', '0');
+    };
+    if ($colorText) {
+        push(@colorList, '--color', "FONT#${colorText}");
+    };
+    if ($colorBorder) {
+        push(@colorList, '--color', "FRAME#${colorBorder}");
+    };
+    if ($colorBackground) {
+        push(@colorList, '--color', "SHADEA#${colorBackground}");
+        push(@colorList, '--color', "SHADEB#${colorBackground}");
+        push(@colorList, '--color', "BACK#${colorBackground}");
+        push(@colorList, '--color', "CANVAS#${colorBackground}");
+    };
+
+    if (@colorList) { return @colorList[0..$#colorList] };
+
+    # Otherwise use rrdtool defaults
+    return
 }
 
 sub get_multi_detail ($$$$;$){


### PR DESCRIPTION
This PR supports configuration of graph background, frame and text colors via the `Presentation` configuration file.

* `colortext` - sets color of graph text
* `colorbackground` - sets color of graph background, canvas, etc.
* `colorborder` - sets color of border around graph

All values take six digit hex RGB values, consistent with other color settings. 