### PR TITLE
Two modules in PERL_MODULES are unused

### DIFF
--- a/PERL_MODULES
+++ b/PERL_MODULES
@@ -16,5 +16,3 @@ Authen::Radius
 Path::Tiny
 InfluxDB::HTTP
 InfluxDB::LineProtocol
-JSON::MaybeXS
-Object::Result


### PR DESCRIPTION
No reference to them can be found in the codebase.

Closes: #334