### PR TITLE
Keep a trace of why we need JSON::MaybeXS and Object::Result

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,5 +16,8 @@ requires 'Authen::Radius';
 requires 'Path::Tiny';
 requires 'InfluxDB::HTTP';
 requires 'InfluxDB::LineProtocol';
+# JSON::MaybeXS and Object::Result are required by InfluxDB::HTTP but were not
+# listed in that lib's dependencies, so we need to cover for them here.
+# See: https://github.com/raphaelthomas/InfluxDB-HTTP/issues/10
 requires 'JSON::MaybeXS';
 requires 'Object::Result';


### PR DESCRIPTION
Both of them can't be found in the smokeping codebase which is
confusing. The reason this was added in was that the InfluxDB::HTTP
library doesn't specify them as dependencies even though it's using
them.

Closes: #334 