### PR TITLE
influxdb authentication: set authorization header manually

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+
+ - InfluxDB 2.x v1 (compatibility) api doesn't set the "WWW-Authenticate" header (violating rfc7235).
+   Work around this issue by manually setting the Authorization header @HandyMenny
  - use actual link for form submission @michaelharo
  - allow to enable/disable autorefresh from ui @Fantros
  - make image responsive @HinataKato

--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,7 @@ requires 'IO::Pty';
 requires 'LWP';
 requires 'Authen::Radius';
 requires 'Path::Tiny';
+requires 'MIME::Base64';
 requires 'InfluxDB::HTTP';
 requires 'InfluxDB::LineProtocol';
 # JSON::MaybeXS and Object::Result are required by InfluxDB::HTTP but were not

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -23,6 +23,7 @@ use Smokeping::Graphs;
 use URI::Escape;
 use Time::HiRes;
 use Data::Dumper;
+use MIME::Base64;
 # optional dependencies
 # will be imported in case InfluxDB host is configured
 # InfluxDB::HTTP
@@ -4218,13 +4219,11 @@ sub load_cfg ($;$) {
             );
             if (defined $cfg->{'InfluxDB'}{'username'} && defined $cfg->{'InfluxDB'}{'password'}) {
                 do_log("DBG: Setting credentials for InfluxDB connection");
+                my $username = $cfg->{'InfluxDB'}{'username'};
+                my $password = $cfg->{'InfluxDB'}{'password'};
+                my $basicauth = encode_base64("$username:$password");
                 my $ua = $influx->get_lwp_useragent();
-                $ua->credentials(
-                    $cfg->{'InfluxDB'}{'host'} . ':' . $cfg->{'InfluxDB'}{'port'},
-                    'InfluxDB',
-                    $cfg->{'InfluxDB'}{'username'},
-                    $cfg->{'InfluxDB'}{'password'}
-                );
+                $ua->default_header('Authorization',  "Basic $basicauth");
             }
         }
         $cfg->{__parser} = $parser;


### PR DESCRIPTION
InfluxDB 2.x v1 (compatibility) api doesn't set the "WWW-Authenticate" header (violating rfc7235).

Work around this issue by manually setting the Authorization header.

See: https://github.com/influxdata/influxdb/issues/24219