### PR TITLE
Support parsing IPv6 output in OpenSSHJunOSPing Plugin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-
+ - Support parsing IPv6 output in OpenSSHJunOSPing Plugin @zimage
  - Enhancement to SSHProbe allows specification of IPv4 vs IPv6 transport, #385
  - InfluxDB 2.x v1 (compatibility) api doesn't set the "WWW-Authenticate" header (violating rfc7235).
    Work around this issue by manually setting the Authorization header @HandyMenny

--- a/lib/Smokeping/probes/OpenSSHJunOSPing.pm
+++ b/lib/Smokeping/probes/OpenSSHJunOSPing.pm
@@ -124,7 +124,7 @@ sub pingone ($$){
     my @times = ();
     for (@output){
     	chomp;
-        /^\d+ bytes from \S+: icmp_seq=\d+ ttl=\d+ time=(\d+\.\d+) ms$/ and push @times,$1;
+        /^\d+ bytes from \S+[:,] icmp_seq=\d+ (?:ttl|hlim)=\d+ time=(\d+\.\d+) ms$/ and push @times,$1;
     }
     @times = map {sprintf "%.10e", $_ / $self->{pingfactor}} sort {$a <=> $b} @times;
     return @times;


### PR DESCRIPTION
When pinging by DNS name on Junos, the ping may use IPv4 or IPv6 and the output is different between the two

**IPv4 output**
```
PING dns.google (8.8.8.8): 64 data bytes
72 bytes from 8.8.8.8: icmp_seq=0 ttl=122 time=0.549 ms
72 bytes from 8.8.8.8: icmp_seq=1 ttl=122 time=0.503 ms
72 bytes from 8.8.8.8: icmp_seq=2 ttl=122 time=0.853 ms
72 bytes from 8.8.8.8: icmp_seq=3 ttl=122 time=0.839 ms
72 bytes from 8.8.8.8: icmp_seq=4 ttl=122 time=0.850 ms

--- dns.google ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max/stddev = 0.503/0.719/0.853/0.158 ms
```

**IPv6 output**
```
PING6(112=40+8+64 bytes) 2605:ce80::2 --> 2001:4860:4860::8844
72 bytes from 2001:4860:4860::8844, icmp_seq=0 hlim=122 time=0.631 ms
72 bytes from 2001:4860:4860::8844, icmp_seq=1 hlim=122 time=0.601 ms
72 bytes from 2001:4860:4860::8844, icmp_seq=2 hlim=122 time=0.617 ms
72 bytes from 2001:4860:4860::8844, icmp_seq=3 hlim=122 time=35.073 ms
72 bytes from 2001:4860:4860::8844, icmp_seq=4 hlim=122 time=3.637 ms

--- dns.google ping6 statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max/std-dev = 0.601/8.112/35.073/13.531 ms
```

This patch changes the regular expression used to parse out the "time" value.
TBH, the expression could be simplified to `/^.* time=(\d+\.\d+) ms$/ and push @times,$1;`, but I didn't want to change too much.