### PR TITLE
Allow all characters in filter menu queries

### DIFF
--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1718,7 +1718,7 @@ sub display_webpage($$){
     my $open_orig = [@$open];
     $open_orig->[-1] .= '~'.$slave if $slave;
 
-    my($filter) = ($q->param('filter') and $q->param('filter') =~ m{([- _0-9a-zA-Z\+\*\(\)\|\^\[\]\.\$]+)});
+    my($filter) = $q->param('filter');
 
     my $tree = $cfg->{Targets};
     if ($hierarchy){


### PR DESCRIPTION
Context: on my instance, I label most locations as `[CC] ISP Name`, where CC is the country code of the target. 

It's not clear to me why the filter menu only accepts some characters. Removing this restriction allows me to search for locations such as `\[US`, as well as ISPs with symbols in their name like "AT&T". (Currently, backslashes in a query seem to be ignored, so a query like `\[US` throws an error about the unmatched brace)

Alternatively, if the goal is to only support a subset of regex (performance reasons?), it would be nice to have an option to make all filter queries literal searches.