### PR TITLE
Add "literalsearch" option to filter targets using literal strings instead of regex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
  - add fix for curl feature checking introduced in curl 7.74 and later @matellis
  - enhancement to extend color handling, making dark templates easier to do @matellis
  - enhancement to remove more borders with graphborders set to no @matellis
+ - add "literalsearch" option to filter targets using literal strings instead
+ of regex @jlu5
 
 2021-08-13 08:12:06 +0200 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/etc/config.dist.in
+++ b/etc/config.dist.in
@@ -50,6 +50,8 @@ AVERAGE  0.5 144   2400
 template = @prefix@/etc/basepage.html.dist
 htmltitle = yes
 graphborders = no
+# If enabled, treat all filter menu queries as literal strings instead of regex
+literalsearch = no
 
 + charts
 

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -766,7 +766,7 @@ sub target_menu($$$$;$){
    	    };
 		if ($filter){
 			my $filter_re;
-			if ($cfg->{Presentation}{literalsearch} eq 'yes') {
+			if (($cfg->{Presentation}{literalsearch} || 'no') eq 'yes') {
 				$filter_re = qr/\Q$filter\E/i;
 			} else {
 				$filter_re = qr/$filter/i;
@@ -1725,7 +1725,7 @@ sub display_webpage($$){
     $open_orig->[-1] .= '~'.$slave if $slave;
 
     my $filter;
-    if ($cfg->{Presentation}{literalsearch} eq 'yes') {
+    if (($cfg->{Presentation}{literalsearch} || 'no') eq 'yes') {
         $filter = $q->param('filter');
     } else {
         ($filter) = ($q->param('filter') and $q->param('filter') =~ m{([- _0-9a-zA-Z\+\*\(\)\|\^\[\]\.\$]+)});

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -765,7 +765,13 @@ sub target_menu($$$$;$){
             }
    	    };
 		if ($filter){
-			if (($menu and $menu =~ /$filter/i) or ($title and $title =~ /$filter/i)){
+			my $filter_re;
+			if ($cfg->{Presentation}{literalsearch} eq 'yes') {
+				$filter_re = qr/\Q$filter\E/i;
+			} else {
+				$filter_re = qr/$filter/i;
+			}
+			if (($menu and $menu =~ $filter_re) or ($title and $title =~ $filter_re)){
 				push @matches, ["$path$key$suffix",$menu,$class,$menuclass];
 			};
 			push @matches, target_menu($tree->{$key}, $open, "$path$key.",$filter, $suffix);
@@ -1718,7 +1724,12 @@ sub display_webpage($$){
     my $open_orig = [@$open];
     $open_orig->[-1] .= '~'.$slave if $slave;
 
-    my($filter) = ($q->param('filter') and $q->param('filter') =~ m{([- _0-9a-zA-Z\+\*\(\)\|\^\[\]\.\$]+)});
+    my $filter;
+    if ($cfg->{Presentation}{literalsearch} eq 'yes') {
+        $filter = $q->param('filter');
+    } else {
+        ($filter) = ($q->param('filter') and $q->param('filter') =~ m{([- _0-9a-zA-Z\+\*\(\)\|\^\[\]\.\$]+)});
+    }
 
     my $tree = $cfg->{Targets};
     if ($hierarchy){
@@ -3243,7 +3254,7 @@ Defines how the SmokePing data should be presented.
 DOC
           _sections => [ qw(overview detail charts multihost hierarchies) ],
           _mandatory => [ qw(overview template detail) ],
-          _vars      => [ qw (template charset htmltitle graphborders colortext colorbackground colorborder) ],
+          _vars      => [ qw (template charset htmltitle graphborders literalsearch colortext colorbackground colorborder) ],
           template   => 
          {
           _doc => <<DOC,
@@ -3279,6 +3290,15 @@ DOC
 By default, SmokePing will render gray border on a light gray background,
 if set to 'no' borders will be hidden and the background and canvas
 will be transparent.
+DOC
+           _re  => '(yes|no)',
+           _re_error =>"this must either be 'yes' or 'no'",
+         },
+         literalsearch => {
+           _doc => <<DOC,
+By default, SmokePing will process filter menu queries as regular
+expressions, if set to 'yes' searches will be treated as literal strings
+instead.
 DOC
            _re  => '(yes|no)',
            _re_error =>"this must either be 'yes' or 'no'",


### PR DESCRIPTION
This is a continuation of #407: add an option to process Filter menu targets using literal strings instead of (partially supported) regex