### PR TITLE
Fix error when toggling Auto Refresh

### DIFF
--- a/htdocs/js/smokeping.js
+++ b/htdocs/js/smokeping.js
@@ -150,7 +150,7 @@ Event.observe(
                 }, window.options.step * 1000);
                 $('refresh-button').style.textDecoration = "line-through";
             } else {
-                clearTimeout(reload);
+                clearTimeout(refresh);
                 localStorage.setItem("noRefresh", true);
                $('refresh-button').style.textDecoration = "none";
             }


### PR DESCRIPTION
The clearTimeout call was using the wrong parameter, leading to the error `Uncaught ReferenceError: reload is not defined`.