### PR TITLE
SSH.pm: remove dsa, openssh removed support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+ - remove dsa and add ed25519 in ssh keyscan by @StalkR and @lelutin
+
 2025-02-19 14:07:15 +0100 Tobias Oetiker <tobi@oetiker.ch>
 
  - Enhancements to SSH.pm probe for #431, allowing configurable start-up test host and doc improvements

--- a/lib/Smokeping/probes/SSH.pm
+++ b/lib/Smokeping/probes/SSH.pm
@@ -58,7 +58,7 @@ sub new($$$)
     # no need for this if we run as a cgi
     unless ( $ENV{SERVER_SOFTWARE} ) {
         
-        my $call = "$self->{properties}{binary} -t dsa,rsa,ecdsa $self->{properties}{init_host}";
+        my $call = "$self->{properties}{binary} -t rsa,ecdsa $self->{properties}{init_host}";
         my $return = `$call 2>&1`;
         if ($return =~ m/$ssh_re/s){
             print "### parsing ssh-keyscan output...OK\n";
@@ -153,7 +153,7 @@ sub targetvars {
            keytype => {
                _doc => "Type of key, used in ssh-keyscan -t I<keytype>",
 	       _re => "[ecdr]sa*",
-               _example => 'dsa',
+               _example => 'ecdsa',
                _default => 'rsa',
            },
            port => {


### PR DESCRIPTION
Fixes #410

openssh original announcement https://lists.mindrot.org/pipermail/openssh-unix-announce/2024-January/000156.html

OpenSSH 9.9 disabled DSA by default at compile time https://lists.mindrot.org/pipermail/openssh-unix-announce/2024-September/000159.html

OpenSSH 1.0 removed DSA entirely https://lists.mindrot.org/pipermail/openssh-unix-announce/2025-April/000162.html

this affects Debian 13 Trixie which was released on August 9th. 2025, bug report: https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1110355