### PR TITLE
Switch graphs over to SVG

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
  - remove dsa and add ed25519 in ssh keyscan by @StalkR and @lelutin
  - add support for fwmark option in fping 5.2+. Supports 'fwmark' keyword in FPing probe
+ - switch graphs from PNG to SVG, to handle automatically both low- and hi-dpi screens
 
 2025-02-19 14:07:15 +0100 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1003,15 +1003,15 @@ sub get_overview ($$$$){
                   "GPRINT:avmsr$i:%5.1lf %s am/as\\l";
 
         }
-        my ($graphret,$xs,$ys) = RRDs::graph 
-          ($cfg->{General}{imgcache}.$dir."/${prop}_mini.png",
+        my ($graphret,$xs,$ys) = RRDs::graph
+          ($cfg->{General}{imgcache}.$dir."/${prop}_mini.svg",
     #       '--lazy',
            '--start','-'.exp2seconds($cfg->{Presentation}{overview}{range}),
            '--title',$cfg->{Presentation}{htmltitle} ne 'yes' ? $phys_tree->{title} : '',
            '--height',$cfg->{Presentation}{overview}{height},
            '--width',$cfg->{Presentation}{overview}{width},
            '--vertical-label', $ProbeUnit,
-           '--imgformat','PNG',
+           '--imgformat','SVG',
            Smokeping::Graphs::get_colors($cfg),
            '--alt-autoscale-max',
            '--alt-y-grid',
@@ -1030,7 +1030,7 @@ sub get_overview ($$$$){
         } else {
          $page.="<A HREF=\"".lnk($q, (join ".", @$open, ${prop}))."\">".
             "<IMG ALT=\"\" WIDTH=\"$xs\" HEIGHT=\"$ys\" ".
-            "SRC=\"".$cfg->{General}{imgurl}.$dir."/${prop}_mini.png\"></A>";
+            "SRC=\"".$cfg->{General}{imgurl}.$dir."/${prop}_mini.svg\"></A>";
         }
         $page .="</div></div>\n";
     }
@@ -1219,7 +1219,7 @@ sub get_detail ($$$$;$){
         my $name = $slave ? " as seen from ". $cfg->{Slaves}{$slave}{display_name} : "";
         mkdir $cfg->{General}{imgcache}."/__navcache",0755  unless -d  $cfg->{General}{imgcache}."/__navcache";
         # remove old images after one hour
-        my $pattern = $cfg->{General}{imgcache}."/__navcache/*.png";
+        my $pattern = $cfg->{General}{imgcache}."/__navcache/*.svg";
         for (glob $pattern){
                 unlink $_ if time - (stat $_)[9] > 3600;
         }
@@ -1251,7 +1251,7 @@ sub get_detail ($$$$;$){
         # chart mode 
         mkdir $cfg->{General}{imgcache}."/__chartscache",0755  unless -d  $cfg->{General}{imgcache}."/__chartscache";
         # remove old images after one hour
-        my $pattern = $cfg->{General}{imgcache}."/__chartscache/*.png";
+        my $pattern = $cfg->{General}{imgcache}."/__chartscache/*.svg";
         for (glob $pattern){
                 unlink $_ if time - (stat $_)[9] > 3600;
         }
@@ -1458,7 +1458,7 @@ sub get_detail ($$$$;$){
                 $title = "$desc from " . ($s ? $cfg->{Slaves}{$slave}{display_name}: $cfg->{General}{display_name} || hostname) . " to $phys_tree->{title}";
             }
             my @task =
-               ("${imgbase}${s}_${end}_${start}.png",
+               ("${imgbase}${s}_${end}_${start}.svg",
                @lazy,
                '--start',$realstart,
                ($end ne 'last' ? ('--end',$end) : ()),
@@ -1470,7 +1470,7 @@ sub get_detail ($$$$;$){
                @log,
                '--lower-limit',(@log ? ($max->{$s}{$start} > 0.01) ? '0.001' : '0.0001' : '0'),
                '--vertical-label',$ProbeUnit,
-               '--imgformat','PNG',
+               '--imgformat','SVG',
                Smokeping::Graphs::get_colors($cfg),
                (map {"DEF:ping${_}=${rrd}:ping${_}:AVERAGE"} 1..$pings),
                (map {"CDEF:cp${_}=ping${_},$max->{$s}{$start},LT,ping${_},INF,IF"} 1..$pings),
@@ -1504,15 +1504,15 @@ sub get_detail ($$$$;$){
         }
 
         if ($mode eq 'a'){ # ajax mode
-             open my $img, "${imgbase}_${end}_${start}.png" or die "${imgbase}_${end}_${start}.png: $!";
+             open my $img, "${imgbase}_${end}_${start}.svg" or die "${imgbase}_${end}_${start}.svg: $!";
              binmode $img;
-             print "Content-Type: image/png\n";
+             print "Content-Type: image/svg+xml\n";
              my $data;
              read($img,$data,(stat($img))[7]);
              close $img;
              print "Content-Length: ".length($data)."\n\n";
              print $data;
-             unlink "${imgbase}_${end}_${start}.png";
+             unlink "${imgbase}_${end}_${start}.svg";
              return undef;
         } 
         elsif ($mode eq 'n'){ # navigator mode
@@ -1522,7 +1522,7 @@ sub get_detail ($$$$;$){
                 $page .= "<div class=\"".panel_heading_class()."\"><h2>$desc</h2></div>";
             }
            $page .= "<div class=\"panel-body\">";
-           $page .= qq|<IMG alt="" id="zoom" width="$xs{''}" height="$ys{''}" SRC="${imghref}_${end}_${start}.png">| ;
+           $page .= qq|<IMG alt="" id="zoom" width="$xs{''}" height="$ys{''}" SRC="${imghref}_${end}_${start}.svg">| ;
            $page .= $q->start_form(-method=>'POST', -id=>'range_form', -action=>$cfg->{General}{cgiurl})
               . "<p>Time range: "		
               . $q->hidden(-name=>'epoch_start',-id=>'epoch_start')
@@ -1554,14 +1554,14 @@ sub get_detail ($$$$;$){
                 }
                 $page .= "<div class=\"panel-body\">";
                 $page .= ( qq{<a href="}.cgiurl($q,$cfg)."?".hierarchy($q).qq{displaymode=n;start=$startstr;end=now;}."target=".$t.$s.'">'
-                      . qq{<IMG ALT="" SRC="${imghref}${s}_${end}_${start}.png">}."</a>" ); #"
+                      . qq{<IMG ALT="" SRC="${imghref}${s}_${end}_${start}.svg">}."</a>" ); #"
                 $page .= "</div></div>\n";
             }
         } else { # chart mode
             $page .= qq{<div class="panel-body">};
             my $href= (split /~/, (join ".", @$open))[0]; #/ # the link is 'slave free'            
             $page .= (  qq{<a href="}.lnk($q, $href).qq{">}
-                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.png">}."</a>" ); #"
+                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg">}."</a>" ); #"
             $page .= "</div>";
             
         }

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -155,7 +155,7 @@ sub get_multi_detail ($$$$;$){
         }
         mkdir $cfg->{General}{imgcache}."/__navcache",0755  unless -d  $cfg->{General}{imgcache}."/__navcache";
         # remove old images after one hour
-        my $pattern = $cfg->{General}{imgcache}."/__navcache/*.png";
+        my $pattern = $cfg->{General}{imgcache}."/__navcache/*.svg";
         for (glob $pattern){
                 unlink $_ if time - (stat $_)[9] > 3600;
         }
@@ -165,7 +165,7 @@ sub get_multi_detail ($$$$;$){
         # chart mode 
         mkdir $cfg->{General}{imgcache}."/__chartscache",0755  unless -d  $cfg->{General}{imgcache}."/__chartscache";
         # remove old images after one hour
-        my $pattern = $cfg->{General}{imgcache}."/__chartscache/*.png";
+        my $pattern = $cfg->{General}{imgcache}."/__chartscache/*.svg";
         for (glob $pattern){
                 unlink $_ if time - (stat $_)[9] > 3600;
         }
@@ -282,7 +282,7 @@ sub get_multi_detail ($$$$;$){
         push @task, '--lazy' if $mode eq 's' and $lastheight{$start} == $max->{$start};
 
         push @task,
-               "${imgbase}_${end}_${start}.png",
+               "${imgbase}_${end}_${start}.svg",
                '--start',$realstart,
                ($end ne 'last' ? ('--end',$end) : ()),
                '--height',$cfg->{Presentation}{detail}{height},
@@ -291,7 +291,7 @@ sub get_multi_detail ($$$$;$){
                '--rigid','--upper-limit', $max->{$start},
                '--lower-limit',($cfg->{Presentation}{detail}{logarithmic} ? ($max->{$start} > 0.01) ? '0.001' : '0.0001' : '0'),
                '--vertical-label',$ProbeUnit,
-               '--imgformat','PNG',
+               '--imgformat','SVG',
                Smokeping::Graphs::get_colors($cfg),
                 @G,
                "COMMENT:$ProbeDesc",
@@ -307,15 +307,15 @@ sub get_multi_detail ($$$$;$){
         
 
         if ($mode eq 'a'){ # ajax mode
-             open my $img, "${imgbase}_${end}_${start}.png";
+             open my $img, "${imgbase}_${end}_${start}.svg";
              binmode $img;
-             print "Content-Type: image/png\n";
+             print "Content-Type: image/svg+xml\n";
              my $data;
              read($img,$data,(stat($img))[7]);
              close $img;
              print "Content-Length: ".length($data)."\n\n";
              print $data;
-             unlink "${imgbase}_${end}_${start}.png";
+             unlink "${imgbase}_${end}_${start}.svg";
              return undef;
         } 
 
@@ -325,7 +325,7 @@ sub get_multi_detail ($$$$;$){
                 if $cfg->{Presentation}{htmltitle} eq 'yes';
             $page .= "<div class=\"panel-body\">";
 
-           $page .= qq|<IMG id="zoom" alt="" width="$xs" height="$ys" SRC="${imghref}_${end}_${start}.png">| ;
+           $page .= qq|<IMG id="zoom" alt="" width="$xs" height="$ys" SRC="${imghref}_${end}_${start}.svg">| ;
 
            $page .= $q->start_form(-method=>'GET', -id=>'range_form')
               . "<p>Time range: "
@@ -352,7 +352,7 @@ sub get_multi_detail ($$$$;$){
                 if $cfg->{Presentation}{htmltitle} eq 'yes';
             $page .= "<div class=\"panel-body\">";
             $page .= ( qq{<a href="?displaymode=n;start=$startstr;end=now;}."target=".$q->param('target').'">'
-                  . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.png" class="img-responsive">}."</a>" ); #"
+                  . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg" class="img-responsive">}."</a>" ); #"
             $page .= "</div></div>\n";
         } else { # chart mode
             $page .= "<div class=\"panel\">";
@@ -360,7 +360,7 @@ sub get_multi_detail ($$$$;$){
                 if $cfg->{Presentation}{htmltitle} eq 'yes';
             $page .= "<div class=\"panel-body\">";
             $page .= (  qq{<a href="}.lnk($q, (join ".", @$open)).qq{">}
-                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.png" class="img-responsive">}."</a>" ); #"
+                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg" class="img-responsive">}."</a>" ); #"
             $page .= "</div></div>\n";
         }
 


### PR DESCRIPTION
This fixes  a very long standing issue regarding the web pages on Hi-DPI screens, as I can find messages from 2017. I filled myself #357 two years ago, but I didn't managed until now to send a patch.

I've been running basically this diff for a couple of years, and it works out of the box on my few installations, on high resolutions screens. I'm not sure how to test on standard resolution screens, but given that I didn't change anything related to resolutions, it should work out of the box.

In #357 I mentioned having a configurable switch, but upon further thinking, and the fact that switching to SVG is transparent, I don't know if there's much gain from keeping both. There is one that might be meaningful - PNG files, being binary, are "natively" compressed. SVG files are not by default compressed, and since BREACH, most installations disable compression for HTTPS. However, if this is a concern, compression on SVG paths can be enabled in a server configuration, as all the XML SVG files should not contain any tokens. Happy to further discuss this concern.