### PR TITLE
Replace semicolons with ampersands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - Replace semicolons with ampersands in URL parameters @svenvg93
  - fix AnotherCurl.pm to use --help all  @Strykar
  - remove dsa and add ed25519 in ssh keyscan by @StalkR and @lelutin
  - add support for fwmark option in fping 5.2+. Supports 'fwmark' keyword in FPing probe

--- a/htdocs/js/smokeping.js
+++ b/htdocs/js/smokeping.js
@@ -108,7 +108,7 @@ function changeRRDImage(coords,dimensions){
     EndEpoch  =  Math.ceil(EndEpoch + (SelectRight - (RRDImgWidth - RRDRight) ) * DivEpoch / RRDImgUsable * RightFactor);
 
 
-    $('zoom').src = myURL + '?displaymode=a;start=' + StartEpoch + ';end=' + EndEpoch + ';target=' + Target + ';hierarchy=' + Hierarchy;    
+    $('zoom').src = myURL + '?displaymode=a&start=' + StartEpoch + '&end=' + EndEpoch + '&target=' + Target + '&hierarchy=' + Hierarchy;    
 
     myCropper.setParams();
 
@@ -119,7 +119,7 @@ if($('range_form') != null && $('range_form').length){
     $form = $(this);
         var cgiurl = $form.action.split("?");
         var action = $form.serialize().split("&");
-        action = action.map(i=> i + ';');
+        action = action.map(i=> i + '&');
         $form.action = cgiurl[0] + "?" + action[4] + action[5] + action[6] + action[3];
     }));
 }

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1553,7 +1553,7 @@ sub get_detail ($$$$;$){
                     $page .= "<div class=\"".panel_heading_class()."\"><h2>$title</h2></div>";
                 }
                 $page .= "<div class=\"panel-body\">";
-                $page .= ( qq{<a href="}.cgiurl($q,$cfg)."?".hierarchy($q).qq{displaymode=n;start=$startstr;end=now;}."target=".$t.$s.'">'
+                $page .= ( qq{<a href="}.cgiurl($q,$cfg)."?".hierarchy($q).qq{displaymode=n&start=$startstr&end=now&}."target=".$t.$s.'">'
                       . qq{<IMG ALT="" SRC="${imghref}${s}_${end}_${start}.svg">}."</a>" ); #"
                 $page .= "</div></div>\n";
             }

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -351,7 +351,7 @@ sub get_multi_detail ($$$$;$){
             $page .= "<div class=\"panel-heading\"><h2>$desc</h2></div>"
                 if $cfg->{Presentation}{htmltitle} eq 'yes';
             $page .= "<div class=\"panel-body\">";
-            $page .= ( qq{<a href="?displaymode=n;start=$startstr;end=now;}."target=".$q->param('target').'">'
+            $page .= ( qq{<a href="?displaymode=n&start=$startstr&end=now&}."target=".$q->param('target').'">'
                   . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg" class="img-responsive">}."</a>" ); #"
             $page .= "</div></div>\n";
         } else { # chart mode


### PR DESCRIPTION
### Problem

SmokePing uses semicolons (;) as URL parameter separators, which are blocked or mangled by modern reverse proxies like Tailscale, Cloudflare, and others due to security concerns (path traversal attacks).

### Solution
Replace semicolons with ampersands (&) in URL generation.

Closes https://github.com/oetiker/SmokePing/issues/459