### PR TITLE
fix: respect `linkstyle=relative` in navigator mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - corrects the behaviour of the navigator mode graphs to respect linkstyle=relative @MattKobayashi
  - Replace semicolons with ampersands in URL parameters @svenvg93
  - fix AnotherCurl.pm to use --help all  @Strykar
  - remove dsa and add ed25519 in ssh keyscan by @StalkR and @lelutin

--- a/htdocs/js/smokeping.js
+++ b/htdocs/js/smokeping.js
@@ -116,11 +116,21 @@ function changeRRDImage(coords,dimensions){
 
 if($('range_form') != null && $('range_form').length){
     $('range_form').on('submit', (function() {
-    $form = $(this);
-        var cgiurl = $form.action.split("?");
+        $form = $(this);
+
+        // IMPORTANT: avoid using `$form.action` as the base URL.
+        // Browsers expose it as an absolute URL even when the HTML `action`
+        // attribute is relative/empty, which breaks `linkstyle=relative`.
+        // Prefer the literal attribute value; if missing, treat it as empty.
+        var actionAttr = $form.readAttribute('action');
+        var cgiurl = ((actionAttr === null) ? '' : actionAttr).split("?");
+
         var action = $form.serialize().split("&");
         action = action.map(i=> i + '&');
-        $form.action = cgiurl[0] + "?" + action[4] + action[5] + action[6] + action[3];
+
+        // Preserve the existing ordering logic, but write back a relative action
+        // when the configured linkstyle resolves to relative.
+        $form.writeAttribute('action', cgiurl[0] + "?" + action[4] + action[5] + action[6] + action[3]);
     }));
 }
 

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -1523,7 +1523,11 @@ sub get_detail ($$$$;$){
             }
            $page .= "<div class=\"panel-body\">";
            $page .= qq|<IMG alt="" id="zoom" width="$xs{''}" height="$ys{''}" SRC="${imghref}_${end}_${start}.svg">| ;
-           $page .= $q->start_form(-method=>'POST', -id=>'range_form', -action=>$cfg->{General}{cgiurl})
+           $page .= $q->start_form(
+                 -method => 'POST',
+                 -id     => 'range_form',
+                 -action => cgiurl($q, $cfg),
+             )
               . "<p>Time range: "
               . $q->hidden(-name=>'epoch_start',-id=>'epoch_start')
               . $q->hidden(-name=>'hierarchy',-id=>'hierarchy')

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -326,8 +326,12 @@ sub get_multi_detail ($$$$;$){
             $page .= "<div class=\"panel-body\">";
 
            $page .= qq|<IMG id="zoom" alt="" width="$xs" height="$ys" SRC="${imghref}_${end}_${start}.svg">| ;
-
-           $page .= $q->start_form(-method=>'GET', -id=>'range_form')
+ 
+           $page .= $q->start_form(
+                 -method => 'GET',
+                 -id     => 'range_form',
+                 -action => Smokeping::cgiurl($q, $cfg),
+             )
               . "<p>Time range: "
               . $q->textfield(-name=>'start',-default=>$startstr)
               . "&nbsp;&nbsp;to&nbsp;&nbsp;".$q->textfield(-name=>'end',-default=>$endstr)


### PR DESCRIPTION
The current behaviour of the "Generate!" button on graphs in navigator mode hard-codes the value of `cgiurl` in the form's POST action, instead of respecting `linkstyle=relative`. This PR corrects the behaviour of the navigator mode graphs to respect `linkstyle=relative`.