### PR TITLE
Fix English "allows one to" in docs

### DIFF
--- a/lib/Smokeping/probes/CiscoRTTMonDNS.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonDNS.pm
@@ -60,7 +60,7 @@ If you want to be a bit more restrictive with SNMP write access to the router, t
 The above configuration grants SNMP read-write only to 10.37.3.5 (the smokeping host) and only to the ciscoRttMon MIB tree. The probe does not need access to SNMP variables outside the RttMon tree.
 DOC
 		bugs => <<DOC,
-The probe does unnecessary DNS queries, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows to set a total time for all queries in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the timeout value hardcoded into this probe).
+The probe does unnecessary DNS queries, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows one to set a total time for all queries in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the timeout value hardcoded into this probe).
 DOC
 		see_also => <<DOC,
 L<http://oss.oetiker.ch/smokeping/>

--- a/lib/Smokeping/probes/CiscoRTTMonEchoICMP.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonEchoICMP.pm
@@ -59,7 +59,7 @@ If you want to be a bit more restrictive with SNMP write access to the router, t
 The above configuration grants SNMP read-write only to 10.37.3.5 (the smokeping host) and only to the ciscoRttMon MIB tree. The probe does not need access to SNMP variables outside the RttMon tree.
 DOC
 		bugs => <<DOC,
-The probe sends unnecessary pings, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows to set a total time for all pings in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the ping timeout value hardcoded into this probe).
+The probe sends unnecessary pings, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows one to set a total time for all pings in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the ping timeout value hardcoded into this probe).
 DOC
 		see_also => <<DOC,
 L<http://oss.oetiker.ch/smokeping/>

--- a/lib/Smokeping/probes/CiscoRTTMonTcpConnect.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonTcpConnect.pm
@@ -54,7 +54,7 @@ If you want to be a bit more restrictive with SNMP write access to the router, t
 The above configuration grants SNMP read-write only to 10.37.3.5 (the smokeping host) and only to the ciscoRttMon MIB tree. The probe does not need access to SNMP variables outside the RttMon tree.
 DOC
 		bugs => <<DOC,
-The probe establishes unnecessary connections, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows to set a total time for all connections in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the timeout value hardcoded into this probe).
+The probe establishes unnecessary connections, i.e. more than configured in the "pings" variable, because the RTTMon MIB only allows one to set a total time for all connections in one measurement run (one "life"). Currently the probe sets the life duration to "pings"*5+3 seconds (5 secs is the timeout value hardcoded into this probe).
 DOC
 		see_also => <<DOC,
 L<http://oss.oetiker.ch/smokeping/>


### PR DESCRIPTION
You don't say "allows to" in proper English, it is correctly "allows one to". This sounds strange for a German native speaker (I am one myself), but Debian's lintian flags this, so I don't have any reason that this is incorrect.