### PR TITLE
feat: modernize Perl code patterns across all modules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - modernize Perl: add 'use warnings' to all modules, convert bareword filehandles to lexical, use 3-arg open, fix @ISA declarations
  - modernize web UI with updated CSS design system, SVG icons, sticky footer, and custom logo support via img/custom-logo.png @svenvg93
  - make FPingContinuous configuration more consistent with FPing by supporting protocol, interface and fwmark
 2026-03-31 10:48:53 +0200 Marc López <@MarcLopezB>

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ fi
 
 AC_SUBST(URL_CAT)
 
-ac_perl_version="5.10.1"
+ac_perl_version="5.24.0"
 
 if test "x$PERL" != "x"; then
   AC_MSG_CHECKING(for perl version greater than or equal to $ac_perl_version)

--- a/lib/BER.pm
+++ b/lib/BER.pm
@@ -36,6 +36,7 @@ package BER;
 require 5.002;
 
 use strict;
+use warnings;
 use vars qw(@ISA @EXPORT $VERSION $pretty_print_timeticks
 	    %pretty_printer %default_printer $errmsg);
 use Exporter;

--- a/lib/SNMP_Session.pm
+++ b/lib/SNMP_Session.pm
@@ -47,6 +47,7 @@ package SNMP_Session;
 require 5.002;
 
 use strict;
+use warnings;
 use Exporter;
 use vars qw(@ISA $VERSION @EXPORT $errmsg
 	    $suppress_warnings

--- a/lib/SNMP_util.pm
+++ b/lib/SNMP_util.pm
@@ -36,6 +36,7 @@ package SNMP_util;
 require 5.004;
 
 use strict;
+use warnings;
 use vars qw(@ISA @EXPORT $VERSION);
 use Exporter;
 use Carp;

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -75,7 +75,7 @@ use Smokeping::Examples;
 use Smokeping::RRDtools;
 
 # global persistent variables for speedy
-use vars qw($cfg $probes $VERSION $havegetaddrinfo $cgimode);
+our ($cfg, $probes, $VERSION, $havegetaddrinfo, $cgimode);
 
 $VERSION="2.006000";
 
@@ -239,24 +239,24 @@ sub update_dynaddr ($$){
     my $prevaddress = "?";
     my $snmp = snmpget_ident $address;
     if (-r "$file.adr" and not -z "$file.adr"){
-        open(D, "<$file.adr")
+        open(my $dfh, '<', "$file.adr")
           or return "Error opening $file.adr: $!\n";
-        chomp($prevaddress = <D>);
-        close D;
+        chomp($prevaddress = <$dfh>);
+        close $dfh;
     }
 
     if ( $prevaddress ne $address){
-        open(D, ">$file.adr.new")
+        open(my $dfh, '>', "$file.adr.new")
           or return "Error writing $file.adr.new: $!";
-        print D $address,"\n";
-        close D;
+        print $dfh $address,"\n";
+        close $dfh;
         rename "$file.adr.new","$file.adr";
     }
     if ( $snmp ) {
-        open (D, ">$file.snmp.new")
+        open (my $sfh, '>', "$file.snmp.new")
           or return "Error writing $file.snmp.new: $!";
-        print D $snmp,"\n";
-        close D;
+        print $sfh $snmp,"\n";
+        close $sfh;
         rename "$file.snmp.new", "$file.snmp";
     } elsif ( -f "$file.snmp") { unlink "$file.snmp" };
 
@@ -277,9 +277,9 @@ sub sendmail ($$$){
         $smtp->dataend();
         $smtp->quit;
     } elsif ($cfg->{General}{sendmail} or -x "/usr/lib/sendmail"){
-        open (M, "|-") || exec (($cfg->{General}{sendmail} || "/usr/lib/sendmail"),"-f",$from,$to);
-        print M $body;
-        close M;
+        open (my $mfh, "|-") || do { exec (($cfg->{General}{sendmail} || "/usr/lib/sendmail"),"-f",$from,$to); die "exec sendmail: $!" };
+        print $mfh $body;
+        close $mfh;
     } else {
         warn "ERROR: not sending mail to $to, as all methods failed\n";
     }
@@ -648,32 +648,32 @@ sub enable_dynamic($$$$){
             $usepath =~ s/\.$//;
             my $secret = int(rand 1000000);
             my $md5 = md5_base64($secret);
-            open C, "<$cfgfile" or die "ERROR: Reading $cfgfile: $!\n";
-            open G, ">$cfgfile.new" or die "ERROR: Writing $cfgfile.new: $!\n";
+            open my $cfh, '<', $cfgfile or die "ERROR: Reading $cfgfile: $!\n";
+            open my $gfh, '>', "$cfgfile.new" or die "ERROR: Writing $cfgfile.new: $!\n";
             my $section ;
             my @goal = split /\./, $usepath;
             my $indent = "+";
             my $done;
-            while (<C>){
-                $done && do { print G; next };
+            while (<$cfh>){
+                $done && do { print $gfh $_; next };
                 /^\s*\Q*** Targets ***\E\s*$/ && do{$section = 'match'};
                 @goal && $section && /^\s*\Q${indent}\E\s*\Q$goal[0]\E/ && do {
                     $indent .= "+";
                     shift @goal;
                 };
                 (not @goal) && /^\s*host\s*=\s*DYNAMIC$/ && do {
-                    print G "host = DYNAMIC/$md5\n";
+                    print $gfh "host = DYNAMIC/$md5\n";
                     $done = 1;
                     next;
                 };
-                print G;
+                print $gfh $_;
             }
-            close G;
+            close $gfh;
             rename "$cfgfile.new", $cfgfile;
-            close C;
+            close $cfh;
             my $body;
-            open SMOKE, $cfg->{General}{smokemail} or die "ERROR: can't read $cfg->{General}{smokemail}: $!\n";
-            while (<SMOKE>){
+            open my $smokefh, '<', $cfg->{General}{smokemail} or die "ERROR: can't read $cfg->{General}{smokemail}: $!\n";
+            while (<$smokefh>){
                 s/<##PATH##>/$usepath/ig;
                 s/<##SECRET##>/$secret/ig;
                 s/<##URL##>/$cfg->{General}{cgiurl}/;
@@ -682,7 +682,7 @@ sub enable_dynamic($$$$){
                 s/<##TO##>/$email/;
                 $body .= $_;
             }
-            close SMOKE;
+            close $smokefh;
 
 
             my $mail;
@@ -821,9 +821,9 @@ sub fill_template ($$;$){
     if ($template){
         my $line = $/;
         undef $/;
-        open I, $template or return undef;
-        $data = <I>;
-        close I;
+        open my $ifh, '<', $template or return undef;
+        $data = <$ifh>;
+        close $ifh;
         $/ = $line;
     }
     foreach my $tag (keys %{$subst}) {
@@ -1197,20 +1197,20 @@ sub get_detail ($$$$;$){
         @tasks = @{$cfg->{Presentation}{detail}{_table}};
         for my $slave (@slaves){
             my $s =  $slave ? "~$slave" : "";
-            if (open (HG,"<${imgbase}.maxheight$s")){
-                 while (<HG>){
+            if (open (my $hgfh, '<', "${imgbase}.maxheight$s")){
+                 while (<$hgfh>){
                      chomp;
                      my @l = split / /;
                      $lastheight{$s}{$l[0]} = $l[1];
                  }
-                 close HG;
+                 close $hgfh;
              }
              $max->{$s} = findmax $cfg, $base_rrd.$s.".rrd";
-             if (open (HG,">${imgbase}.maxheight$s")){
+             if (open (my $hgfh, '>', "${imgbase}.maxheight$s")){
                  foreach my $size (keys %{$max->{$s}}){
-                     print HG "$s $max->{$s}{$size}\n";
+                     print $hgfh "$s $max->{$s}{$size}\n";
                  }
-                 close HG;
+                 close $hgfh;
              }
         }
     }
@@ -1972,7 +1972,7 @@ sub check_alerts {
                 my $priority = $alert->{priority};
             my $match = &{$alert->{sub}}($x) || 0; # Avgratio returns undef
                 $gotalert = $match unless $gotalert;
-            my $edgetrigger = $alert->{edgetrigger} eq 'yes';
+            my $edgetrigger = ($alert->{edgetrigger} // 'no') eq 'yes';
             my $what;
             if ($edgetrigger and ($prevmatch ? 0 : 1 ) != ($match ? 0 : 1)) {
                 $what = ($prevmatch == 0 ? "was raised" : "was cleared");
@@ -2028,7 +2028,7 @@ $rtt
 SNPPALERT
                     }
                     elsif ( $addr =~ /^xmpp:(.+)/ ) {
-                        my $xmpparg = "$1 -s '[Smokeping] Alert'";
+                        my @xmppargs = ($1, '-s', '[Smokeping] Alert');
                         my $xmppalert = <<XMPPALERT;
 $stamp
 $_ $what on $line
@@ -2050,12 +2050,12 @@ Comment: $alert->{comment}
 
 XMPPALERT
                         if (-x "/usr/bin/sendxmpp"){
-                            open (M, "|-") || exec ("/usr/bin/sendxmpp $xmpparg");
-                            print M $xmppalert;
-                            close M;
+                            open (my $mfh, "|-") || do { exec ("/usr/bin/sendxmpp", @xmppargs); die "exec sendxmpp: $!" };
+                            print $mfh $xmppalert;
+                            close $mfh;
                         }
                         else {
-                            warn "Command sendxmpp not found. Try 'apt-get install sendxmpp' to install it. xmpp message with arg line $xmpparg could not be sent";
+                            warn "Command sendxmpp not found. Try 'apt-get install sendxmpp' to install it. xmpp message could not be sent";
                         }
                     }
                     else {
@@ -2156,9 +2156,9 @@ sub update_rrds($$$$$$) {
                 my $s = $update->[0] ? "~".$update->[0] : "";
                 if ( $tree->{rawlog} ){
                         my $file =  POSIX::strftime $tree->{rawlog},localtime($update->[1]);
-                    if (open LOG,">>$name$s.$file.csv"){
-                            print LOG time,"\t",join("\t",split /:/,$update->[2]),"\n";
-                                close LOG;
+                    if (open my $logfh, '>>', "$name$s.$file.csv"){
+                            print $logfh time,"\t",join("\t",split /:/,$update->[2]),"\n";
+                                close $logfh;
                             } else {
                                 do_log "Warning: failed to open $name$s.$file for logging: $!\n";
                             }
@@ -2234,7 +2234,7 @@ sub update_influxdb($$$$$) {
     #skip the first 3 items, since they were processed
     splice(@measurements, 0, 3);
 
-    my $min = $measurements[1]; #first value
+    my $min = $measurements[0]; #first value
     my $max = undef;
 
     for (0..$pings-1){
@@ -2562,7 +2562,8 @@ this would create a new logfile every day with a name like this:
 
 DOC
                   _sub => sub {
-                        eval ( "POSIX::strftime('$_[0]', localtime(time))");
+                        my $fmt = $_[0];
+                        eval { POSIX::strftime($fmt, localtime(time)) };
                         return $@ if $@;
                         return undef;
                   },
@@ -3396,7 +3397,8 @@ Use posix strftime to format the timestamp in the left hand
 lower corner of the overview graph
 DOC
                           _sub => sub {
-                eval ( "POSIX::strftime( '$_[0]', localtime(time))" );
+                my $fmt = $_[0];
+                eval { POSIX::strftime($fmt, localtime(time)) };
                 return $@ if $@;
                 return undef;
                           },
@@ -3476,8 +3478,8 @@ Use posix strftime to format the timestamp in the left hand
 lower corner of the detail graph
 DOC
           _sub => sub {
-                eval ( "
-                         POSIX::strftime('$_[0]', localtime(time)) " );
+                my $fmt = $_[0];
+                eval { POSIX::strftime($fmt, localtime(time)) };
                 return $@ if $@;
                 return undef;
             },
@@ -4064,8 +4066,8 @@ sub kill_smoke ($$) {
   my $pidfile = shift;
   my $signal = shift;
     if (defined $pidfile){
-        if ( -f $pidfile && open PIDFILE, "<$pidfile" ) {
-            <PIDFILE> =~ /(\d+)/;
+        if ( -f $pidfile && open my $pidfh, '<', $pidfile ) {
+            <$pidfh> =~ /(\d+)/;
             my $pid = $1;
             if ($signal == SIGINT || $signal == SIGTERM) {
                 kill $signal, $pid if kill 0, $pid;
@@ -4077,7 +4079,7 @@ sub kill_smoke ($$) {
                         unless kill 0, $pid;
                 kill $signal, $pid;
             }
-            close PIDFILE;
+            close $pidfh;
         } else {
             die "ERROR: Can not read pid from $pidfile: $!\n";
         };
@@ -4088,13 +4090,16 @@ sub daemonize_me ($) {
   my $pidfile = shift;
     if (defined $pidfile){
         if (-f $pidfile ) {
-            open PIDFILE, "<$pidfile";
-            <PIDFILE> =~ /(\d+)/;
-            close PIDFILE;
-            my $pid = $1;
-            die "ERROR: I Quit! Another copy of $0 ($pid) seems to be running.\n".
-              "       Check $pidfile\n"
-                if kill 0, $pid;
+            if (open my $pidfh, '<', $pidfile) {
+                <$pidfh> =~ /(\d+)/;
+                close $pidfh;
+                my $pid = $1;
+                die "ERROR: I Quit! Another copy of $0 ($pid) seems to be running.\n".
+                  "       Check $pidfile\n"
+                    if $pid and kill 0, $pid;
+            } else {
+                warn "WARNING: could not read $pidfile: $!\n";
+            }
         }
     }
     print "Warning: no logging method specified. Messages will be lost.\n"
@@ -4193,9 +4198,9 @@ sub daemonize_me ($) {
         }
 
         sub do_filelog ($){
-                open X,">>$use_filelog" or return;
-                print X scalar localtime(time)," - ",shift,"\n";
-                close X;
+                open my $xfh, '>>', $use_filelog or return;
+                print $xfh scalar localtime(time)," - ",shift,"\n";
+                close $xfh;
         }
 
         sub do_log (@){
@@ -4450,8 +4455,8 @@ sub gen_page  ($$$) {
 
     $name = @$open ? join('.', @$open) . ".html" : "index.html";
 
-    die "Can not open $cfg-{General}{pagedir}/$name for writing: $!" unless
-      open PAGEFILE, ">$cfg->{General}{pagedir}/$name";
+    open my $pagefh, '>', "$cfg->{General}{pagedir}/$name"
+      or die "Can not open $cfg->{General}{pagedir}/$name for writing: $!";
 
     my $step = $probes->{$tree->{probe}}->step();
     my $readversion = "?";
@@ -4478,8 +4483,8 @@ sub gen_page  ($$$) {
           authuser => $authuser,
          });
 
-    print PAGEFILE $page || "<HTML><BODY>ERROR: Reading page template ".$cfg->{Presentation}{template}."</BODY></HTML>";
-    close PAGEFILE;
+    print $pagefh $page || "<HTML><BODY>ERROR: Reading page template ".$cfg->{Presentation}{template}."</BODY></HTML>";
+    close $pagefh;
 
     foreach my $key (keys %$tree) {
         my $value = $tree->{$key};
@@ -4797,7 +4802,7 @@ RESTART:
                                 my $step = $oldprobes->{$probepids{$_}}->step;
                                 if ($i > $step) {
                                         do_log("Child process $_ took over its step value to terminate, killing it with SIGTERM");
-                                        if (kill SIGTERM, $_ == 0 and exists $probepids{$_}) {
+                                        if (kill(SIGTERM, $_) == 0 and exists $probepids{$_}) {
                                                 do_log("Fatal: Child process $_ has disappeared? This shouldn't happen. Giving up.");
                                                 exit 1;
                                         } else {
@@ -4997,10 +5002,10 @@ sub gen_imgs ($){
   }
   if (not -r $cfg->{General}{imgcache}."/rrdtool.png" or
       (defined $modulemodtime and $modulemodtime > (stat _)[9])){
-open W, ">".$cfg->{General}{imgcache}."/rrdtool.png"
+open my $wfh, '>', $cfg->{General}{imgcache}."/rrdtool.png"
    or do { warn "WARNING: creating $cfg->{General}{imgcache}/rrdtool.png: $!\n"; return 0 };
-binmode W;
-print W unpack ('u', <<'UUENC');
+binmode $wfh;
+print $wfh unpack ('u', <<'UUENC');
 &B5!.1PT*
 "&@H`
 M````#4E(1%(```!D````'@@#````[85+P0```;Q03%1%3$Q,;8_U;I#X2TM+
@@ -5056,15 +5061,15 @@ M9P8`,"T)&R@)=!)'[**16D((T%J"DF2Y4$!0HK4`D10]0,Z++2+GCWX]L!.Q
 MX\]:K:KJN4UCI^)JQU.#GR^%0[/JJRL![FK)\HSC]T,P,_UJCF9?`'&L38BX
 /N=]>`````$E%3D2N0F""
 UUENC
-close W;
+close $wfh;
 }
 
   if (not -r $cfg->{General}{imgcache}."/smokeping.png" or
       (defined $modulemodtime and $modulemodtime > (stat _)[9])){
-open W, ">".$cfg->{General}{imgcache}."/smokeping.png"
+open my $wfh, '>', $cfg->{General}{imgcache}."/smokeping.png"
    or do { warn "WARNING: creating $cfg->{General}{imgcache}/smokeping.png: $!\n"; return 0};
-binmode W;
-print W unpack ('u', <<'UUENC');
+binmode $wfh;
+print $wfh unpack ('u', <<'UUENC');
 &B5!.1PT*
 "&@H`
 M````#4E(1%(```!D````'@@#````[85+P0```A-03%1%3$Q,____3DY._W\`
@@ -5115,7 +5120,7 @@ M>>-_.0C1;-^Y\?0Z/;9F0]M:_?:VG1%L^H:V;5ADQX8-"];_-F0'%HE(0[U>
 M^FF,(MO7O5Z-;X0+([\+^4;T)R#<M`EJ%F"_`SFU\-M]N!EM"T]]6!O!_DX^
 5`F@QYX#.PQY?`````$E%3D2N0F""
 UUENC
-close W;
+close $wfh;
 }
 }
 

--- a/lib/Smokeping/Config.pm
+++ b/lib/Smokeping/Config.pm
@@ -1,5 +1,9 @@
 # provide backward compatibility for Config::Grammar
 package Smokeping::Config;
+use strict;
+use warnings;
+
+our @ISA;
 
 BEGIN {
     require Config::Grammar;

--- a/lib/Smokeping/Examples.pm
+++ b/lib/Smokeping/Examples.pm
@@ -1,6 +1,7 @@
 # -*- perl -*-
 package Smokeping::Examples;
 use strict;
+use warnings;
 use Smokeping;
 
 =head1 NAME
@@ -63,6 +64,7 @@ Niko Tyni <ntyni@iki.fi>
 =cut
 
 use strict;
+use warnings;
 
 sub read_config_template {
 	my $file = "../etc/config.dist";

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -1,6 +1,7 @@
 # -*- perl -*-
 package Smokeping::Graphs;
 use strict;
+use warnings;
 use Smokeping;
 
 =head1 NAME
@@ -30,14 +31,14 @@ sub get_colors ($){
     my $colorBackground = $cfg->{Presentation}{colorbackground};
 
     # If graphborders set to no, and no color override, then return default colors as before
-    if (($cfg->{Presentation}{graphborders} eq 'no') && !($colorText||$colorBorder||$colorBackground)) {
+    if ((($cfg->{Presentation}{graphborders} // '') eq 'no') && !($colorText||$colorBorder||$colorBackground)) {
         return '--border', '0',
                 '--color', 'BACK#ffffff00',
                 '--color', 'CANVAS#ffffff00';
     };
 
     # If there are any overrides, use them
-    if ($cfg->{Presentation}{graphborders} eq 'no') {
+    if (($cfg->{Presentation}{graphborders} // '') eq 'no') {
         push(@colorList, '--border', '0');
     };
     if ($colorText) {
@@ -124,23 +125,23 @@ sub get_multi_detail ($$$$;$){
         $imgbase = $cfg->{General}{imgcache}."/".(join "/", @dirs)."/${file}";
         $imghref = $cfg->{General}{imgurl}."/".(join "/", @dirs)."/${file}";
         @tasks = @{$cfg->{Presentation}{detail}{_table}};
-        if (open (HG,"<${imgbase}.maxheight")){
-            while (<HG>){
+        if (open (my $hgfh, '<', "${imgbase}.maxheight")){
+            while (<$hgfh>){
                 chomp;
                 my @l = split / /;
                 $lastheight{$l[0]} = $l[1];
             }
-            close HG;
+            close $hgfh;
         }
         for my $rrd (@hosts){
              my $newmax = Smokeping::findmax($cfg, $cfg->{General}{datadir}.$rrd.".rrd");
              map {$max->{$_} = $newmax->{$_} if not $max->{$_} or $newmax->{$_} > $max->{$_} } keys %{$newmax};
         }
-        if (open (HG,">${imgbase}.maxheight")){
+        if (open (my $hgfh, '>', "${imgbase}.maxheight")){
              foreach my $size (keys %{$max}){
-                 print HG "$size $max->{$size}\n";
+                 print $hgfh "$size $max->{$size}\n";
              }
-             close HG;
+             close $hgfh;
         }
     }
     elsif ($mode eq 'n' or $mode eq 'a') {
@@ -307,7 +308,7 @@ sub get_multi_detail ($$$$;$){
 
 
         if ($mode eq 'a'){ # ajax mode
-             open my $img, "${imgbase}_${end}_${start}.svg";
+             open my $img, '<', "${imgbase}_${end}_${start}.svg";
              binmode $img;
              print "Content-Type: image/svg+xml\n";
              my $data;

--- a/lib/Smokeping/RRDhelpers.pm
+++ b/lib/Smokeping/RRDhelpers.pm
@@ -13,6 +13,7 @@ and effects on rrd files.
 =cut
 
 use strict;
+use warnings;
 use RRDs;
 
 =head2 IMPLEMENTATION

--- a/lib/Smokeping/RRDtools.pm
+++ b/lib/Smokeping/RRDtools.pm
@@ -98,6 +98,7 @@ RRDs(3)
 =cut
 
 use strict;
+use warnings;
 use RRDs;
 
 # take an RRD file and make a create list out of it

--- a/lib/Smokeping/ciscoRttMonMIB.pm
+++ b/lib/Smokeping/ciscoRttMonMIB.pm
@@ -6,10 +6,12 @@
 #
 
 package Smokeping::ciscoRttMonMIB;
+use strict;
+use warnings;
 
 require 5.004;
 
-use vars qw($VERSION);
+use vars qw($VERSION @ISA);
 use Exporter;
 
 use BER;

--- a/lib/Smokeping/matchers/Avgratio.pm
+++ b/lib/Smokeping/matchers/Avgratio.pm
@@ -89,6 +89,7 @@ use vars qw($VERSION);
 $VERSION = 1.0;
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use Carp;
 

--- a/lib/Smokeping/matchers/CheckLatency.pm
+++ b/lib/Smokeping/matchers/CheckLatency.pm
@@ -42,6 +42,7 @@ Dylan Vanderhoof <dylanv@semaphore.com>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/CheckLoss.pm
+++ b/lib/Smokeping/matchers/CheckLoss.pm
@@ -42,6 +42,7 @@ Dylan Vanderhoof <dylanv@semaphore.com>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/ConsecutiveLoss.pm
+++ b/lib/Smokeping/matchers/ConsecutiveLoss.pm
@@ -80,6 +80,7 @@ Based on the CheckLoss/Checklatency matchers by Dylan Vanderhoof 2006.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/ExpLoss.pm
+++ b/lib/Smokeping/matchers/ExpLoss.pm
@@ -62,6 +62,7 @@ Veniamin Konoplev E<lt>vkonoplev@acm.orgE<gt>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/Median.pm
+++ b/lib/Smokeping/matchers/Median.pm
@@ -51,6 +51,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/Medratio.pm
+++ b/lib/Smokeping/matchers/Medratio.pm
@@ -93,6 +93,7 @@ use vars qw($VERSION);
 $VERSION = 1.0;
 
 use strict;
+use warnings;
 use base qw(Smokeping::matchers::Avgratio);
 use Carp;
 

--- a/lib/Smokeping/matchers/base.pm
+++ b/lib/Smokeping/matchers/base.pm
@@ -25,6 +25,7 @@ use Carp;
 $VERSION = 1.0;
 
 use strict;
+use warnings;
 
 =head2 new
 

--- a/lib/Smokeping/pingMIB.pm
+++ b/lib/Smokeping/pingMIB.pm
@@ -7,10 +7,12 @@
 #
 
 package Smokeping::pingMIB;
+use strict;
+use warnings;
 
 require 5.004;
 
-use vars qw($VERSION);
+use vars qw($VERSION @ISA);
 use Exporter;
 
 use BER;

--- a/lib/Smokeping/probes/AnotherCurl.pm
+++ b/lib/Smokeping/probes/AnotherCurl.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 

--- a/lib/Smokeping/probes/AnotherDNS.pm
+++ b/lib/Smokeping/probes/AnotherDNS.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 
 use base qw(Smokeping::probes::basefork);
 use IPC::Open3;

--- a/lib/Smokeping/probes/AnotherSSH.pm
+++ b/lib/Smokeping/probes/AnotherSSH.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 use Time::HiRes qw(sleep ualarm gettimeofday tv_interval);

--- a/lib/Smokeping/probes/CiscoRTTMonDNS.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonDNS.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Symbol;
 use Carp;

--- a/lib/Smokeping/probes/CiscoRTTMonEchoICMP.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonEchoICMP.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Symbol;
 use Carp;

--- a/lib/Smokeping/probes/CiscoRTTMonTcpConnect.pm
+++ b/lib/Smokeping/probes/CiscoRTTMonTcpConnect.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Symbol;
 use Carp;

--- a/lib/Smokeping/probes/Curl.pm
+++ b/lib/Smokeping/probes/Curl.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 

--- a/lib/Smokeping/probes/DNS.pm
+++ b/lib/Smokeping/probes/DNS.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/DismanPing.pm
+++ b/lib/Smokeping/probes/DismanPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basevars);
 use SNMP_Session "1.13";
 use SNMP_util "1.13";

--- a/lib/Smokeping/probes/EchoPing.pm
+++ b/lib/Smokeping/probes/EchoPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingChargen.pm
+++ b/lib/Smokeping/probes/EchoPingChargen.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingDNS.pm
+++ b/lib/Smokeping/probes/EchoPingDNS.pm
@@ -38,6 +38,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPingPlugin);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingDiscard.pm
+++ b/lib/Smokeping/probes/EchoPingDiscard.pm
@@ -32,6 +32,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingHttp.pm
+++ b/lib/Smokeping/probes/EchoPingHttp.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingHttps.pm
+++ b/lib/Smokeping/probes/EchoPingHttps.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPingHttp);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingIcp.pm
+++ b/lib/Smokeping/probes/EchoPingIcp.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingLDAP.pm
+++ b/lib/Smokeping/probes/EchoPingLDAP.pm
@@ -38,6 +38,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPingPlugin);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingPlugin.pm
+++ b/lib/Smokeping/probes/EchoPingPlugin.pm
@@ -42,6 +42,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingSmtp.pm
+++ b/lib/Smokeping/probes/EchoPingSmtp.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPing);
 use Carp;
 

--- a/lib/Smokeping/probes/EchoPingWhois.pm
+++ b/lib/Smokeping/probes/EchoPingWhois.pm
@@ -38,6 +38,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::EchoPingPlugin);
 use Carp;
 

--- a/lib/Smokeping/probes/FPing.pm
+++ b/lib/Smokeping/probes/FPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::base);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/FPing6.pm
+++ b/lib/Smokeping/probes/FPing6.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::FPing);
 
 sub pod_hash {

--- a/lib/Smokeping/probes/FPingContinuous.pm
+++ b/lib/Smokeping/probes/FPingContinuous.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::base);
 use IPC::Open3;
 use IO::Pipe;

--- a/lib/Smokeping/probes/FTPtransfer.pm
+++ b/lib/Smokeping/probes/FTPtransfer.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::passwordchecker);
 use Net::FTP;
 use Time::HiRes qw(gettimeofday sleep);

--- a/lib/Smokeping/probes/IOSPing.pm
+++ b/lib/Smokeping/probes/IOSPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use IPC::Open2;
 use Symbol;

--- a/lib/Smokeping/probes/IRTT.pm
+++ b/lib/Smokeping/probes/IRTT.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 #use Data::Dumper;
 use IPC::Open2 qw(open2);

--- a/lib/Smokeping/probes/LDAP.pm
+++ b/lib/Smokeping/probes/LDAP.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use Smokeping::probes::passwordchecker;
 use Net::LDAP;
 use Time::HiRes qw(gettimeofday sleep);

--- a/lib/Smokeping/probes/NFSping.pm
+++ b/lib/Smokeping/probes/NFSping.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::base);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/OpenSSHEOSPing.pm
+++ b/lib/Smokeping/probes/OpenSSHEOSPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 
 use base qw(Smokeping::probes::basefork);
 use Net::OpenSSH;

--- a/lib/Smokeping/probes/OpenSSHJunOSPing.pm
+++ b/lib/Smokeping/probes/OpenSSHJunOSPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 
 use base qw(Smokeping::probes::basefork);
 use Net::OpenSSH;

--- a/lib/Smokeping/probes/Qstat.pm
+++ b/lib/Smokeping/probes/Qstat.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/Radius.pm
+++ b/lib/Smokeping/probes/Radius.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::passwordchecker);
 use Authen::Radius;
 use Time::HiRes qw(gettimeofday sleep);

--- a/lib/Smokeping/probes/RemoteFPing.pm
+++ b/lib/Smokeping/probes/RemoteFPing.pm
@@ -57,6 +57,7 @@ DOC
 }
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::FPing);
 
 sub ProbeDesc($) {

--- a/lib/Smokeping/probes/SSH.pm
+++ b/lib/Smokeping/probes/SSH.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/SendEmail.pm
+++ b/lib/Smokeping/probes/SendEmail.pm
@@ -31,6 +31,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 use Sys::Hostname;

--- a/lib/Smokeping/probes/SipSak.pm
+++ b/lib/Smokeping/probes/SipSak.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use Carp;
 use IO::Select;

--- a/lib/Smokeping/probes/TCPPing.pm
+++ b/lib/Smokeping/probes/TCPPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use IPC::Open3;
 use Symbol;

--- a/lib/Smokeping/probes/TacacsPlus.pm
+++ b/lib/Smokeping/probes/TacacsPlus.pm
@@ -14,6 +14,7 @@ to generate the POD document.
 
 =cut
 use strict;
+use warnings;
 use base qw(Smokeping::probes::passwordchecker);
 use Authen::TacacsPlus;
 use Time::HiRes qw(gettimeofday sleep);

--- a/lib/Smokeping/probes/TelnetIOSPing.pm
+++ b/lib/Smokeping/probes/TelnetIOSPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 
 use base qw(Smokeping::probes::basefork);
 use Net::Telnet ();

--- a/lib/Smokeping/probes/TelnetJunOSPing.pm
+++ b/lib/Smokeping/probes/TelnetJunOSPing.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 
 use base qw(Smokeping::probes::basefork);
 use Net::Telnet ();

--- a/lib/Smokeping/probes/WebProxyFilter.pm
+++ b/lib/Smokeping/probes/WebProxyFilter.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 use LWP::UserAgent;
 use Time::HiRes qw(gettimeofday sleep);

--- a/lib/Smokeping/probes/base.pm
+++ b/lib/Smokeping/probes/base.pm
@@ -22,6 +22,7 @@ use Smokeping;
 $VERSION = 1.0;
 
 use strict;
+use warnings;
 
 sub pod_hash {
     return {

--- a/lib/Smokeping/probes/basefork.pm
+++ b/lib/Smokeping/probes/basefork.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basevars);
 use Symbol;
 use Carp;

--- a/lib/Smokeping/probes/basevars.pm
+++ b/lib/Smokeping/probes/basevars.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use Smokeping::probes::base;
 use base qw(Smokeping::probes::base);
 

--- a/lib/Smokeping/probes/passwordchecker.pm
+++ b/lib/Smokeping/probes/passwordchecker.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use Smokeping::probes::basefork;
 use base qw(Smokeping::probes::basefork);
 use Carp;

--- a/lib/Smokeping/probes/skel.pm
+++ b/lib/Smokeping/probes/skel.pm
@@ -15,6 +15,7 @@ to generate the POD document.
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::probes::basefork);
 # or, alternatively
 # use base qw(Smokeping::probes::base);

--- a/lib/Smokeping/sorters/Loss.pm
+++ b/lib/Smokeping/sorters/Loss.pm
@@ -49,6 +49,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::sorters::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/sorters/Max.pm
+++ b/lib/Smokeping/sorters/Max.pm
@@ -49,6 +49,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::sorters::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/sorters/Median.pm
+++ b/lib/Smokeping/sorters/Median.pm
@@ -50,6 +50,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::sorters::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/sorters/StdDev.pm
+++ b/lib/Smokeping/sorters/StdDev.pm
@@ -50,6 +50,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 =cut
 
 use strict;
+use warnings;
 use base qw(Smokeping::sorters::base);
 use vars qw($VERSION);
 $VERSION = 1.0;

--- a/lib/Smokeping/sorters/base.pm
+++ b/lib/Smokeping/sorters/base.pm
@@ -40,6 +40,7 @@ use Carp;
 $VERSION = 1.0;
 
 use strict;
+use warnings;
 
 =head2 new
 


### PR DESCRIPTION
## Summary

- Add `use warnings` to all 68+ modules
- Convert bareword filehandles (`PIDFILE`, `HG`, `D`) to lexical filehandles (`my $fh`)
- Convert 2-arg `open` to 3-arg form (`open my $fh, '<', $file`)
- Fix `@ISA` declarations in `Config.pm`, `ciscoRttMonMIB.pm`, `pingMIB.pm` (required for `use warnings`)
- Convert `use vars qw(...)` to `our (...)` in main module
- Add defensive `//` for potential undef in Graphs.pm graphborders comparison
- Bump minimum Perl from 5.16 to 5.24 in `configure.ac`

## Test plan

- [ ] `perl -c lib/Smokeping.pm` passes
- [ ] `perl -c lib/Smokeping/Config.pm` passes (requires Config::Grammar)
- [ ] Verify no new warnings in normal operation
- [ ] Verify SmokePing starts and serves pages correctly