### PR TITLE
refactor: modernize Perl filehandles and variable declarations

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,13 @@
+.git
+.github
+autom4te.cache
+rrdtool-*
+local-rrdtool
+test-install
+thirdparty/lib
+thirdparty/carton
+thirdparty/cache
+thirdparty/touch
+cpanfile.snapshot
+config.log
+config.status

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - modernize Perl: replace use vars with our, two-arg open with three-arg, bareword filehandles with lexical variables @oetiker
  - avoid full page reload on browser resize; update graph width silently for next refresh cycle @oetiker
  - fix graphs disappearing after small browser resizes or sidebar toggle @oetiker
  - clean up CSS: remove duplicate rules, use CSS variables for dark mode @oetiker

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+ - avoid full page reload on browser resize; update graph width silently for next refresh cycle @oetiker
+ - fix graphs disappearing after small browser resizes or sidebar toggle @oetiker
+ - clean up CSS: remove duplicate rules, use CSS variables for dark mode @oetiker
+ - wider browser windows now show longer time spans instead of zooming into the same period @oetiker
+ - render RRD graphs at browser content width for sharper display on wide screens @oetiker
+ - fix graph panels and images to scale responsively to browser width instead of fixed pixel size @oetiker
  - modernize web UI with updated CSS design system, SVG icons, sticky footer, and custom logo support via img/custom-logo.png @svenvg93
  - make FPingContinuous configuration more consistent with FPing by supporting protocol, interface and fwmark
 2026-03-31 10:48:53 +0200 Marc López <@MarcLopezB>

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,66 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SMOKEPING_PREFIX=/opt/smokeping
+
+# System dependencies: build tools + runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Build tools
+    make gcc autoconf automake perl curl ca-certificates \
+    # Runtime: rrdtool + perl bindings
+    rrdtool librrds-perl \
+    # Probes
+    fping dnsutils \
+    # Web server
+    lighttpd \
+    # Perl modules available as system packages
+    libcgi-pm-perl libfcgi-perl libcgi-fast-perl \
+    libwww-perl libnet-dns-perl libnet-snmp-perl \
+    libio-socket-ssl-perl libsocket6-perl \
+    libdigest-hmac-perl libnet-telnet-perl \
+    libnet-ldap-perl libauthen-radius-perl \
+    libpath-tiny-perl libmime-base64-perl \
+    libjson-maybexs-perl \
+    # For cpanm to build XS modules
+    libc6-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install cpanm
+RUN curl -sL https://cpanmin.us | perl - App::cpanminus
+
+# Copy source
+COPY . /build/smokeping
+WORKDIR /build/smokeping
+
+# Install remaining Perl deps not available as system packages
+# Note: InfluxDB::HTTP, InfluxDB::LineProtocol, Object::Result are optional
+# (only needed for InfluxDB integration) and skipped here.
+RUN cpanm --notest --quiet \
+    Net::OpenSSH \
+    IO::Pty \
+    Config::Grammar \
+    FCGI
+
+# Build and install SmokePing
+# Skip thirdparty (deps handled via apt/cpanm) and doc (no man pages needed)
+RUN ./configure --prefix=${SMOKEPING_PREFIX} --enable-pkgonly \
+    && for dir in lib bin etc htdocs; do make -C $dir install; done
+
+# Create required directories
+RUN mkdir -p \
+    ${SMOKEPING_PREFIX}/data \
+    ${SMOKEPING_PREFIX}/cache \
+    ${SMOKEPING_PREFIX}/var
+
+# Install container-specific config files
+COPY container/smokeping-config ${SMOKEPING_PREFIX}/etc/config
+COPY container/lighttpd.conf /etc/lighttpd/lighttpd.conf
+COPY container/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Clean up build directory
+RUN rm -rf /build
+
+EXPOSE 4265
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SMOKEPING_PREFIX=/opt/smokeping
 
-# System dependencies: build tools + runtime
+# Layer 1: System dependencies (cached unless Containerfile changes)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Build tools
     make gcc autoconf automake perl curl ca-certificates \
@@ -25,41 +25,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install cpanm
+# Layer 2: Perl deps from CPAN (cached unless cpanfile changes)
 RUN curl -sL https://cpanmin.us | perl - App::cpanminus
-
-# Copy source
-COPY . /build/smokeping
-WORKDIR /build/smokeping
-
-# Install remaining Perl deps not available as system packages
-# Note: InfluxDB::HTTP, InfluxDB::LineProtocol, Object::Result are optional
-# (only needed for InfluxDB integration) and skipped here.
+COPY cpanfile /tmp/cpanfile
 RUN cpanm --notest --quiet \
     Net::OpenSSH \
     IO::Pty \
     Config::Grammar \
     FCGI
 
-# Build and install SmokePing
+# Layer 3: Build SmokePing from source (rebuilds on code changes)
+COPY . /build/smokeping
+WORKDIR /build/smokeping
 # Skip thirdparty (deps handled via apt/cpanm) and doc (no man pages needed)
 RUN ./configure --prefix=${SMOKEPING_PREFIX} --enable-pkgonly \
-    && for dir in lib bin etc htdocs; do make -C $dir install; done
+    && for dir in lib bin etc htdocs; do make -C $dir install; done \
+    && mkdir -p ${SMOKEPING_PREFIX}/data ${SMOKEPING_PREFIX}/cache ${SMOKEPING_PREFIX}/var \
+    && rm -rf /build
 
-# Create required directories
-RUN mkdir -p \
-    ${SMOKEPING_PREFIX}/data \
-    ${SMOKEPING_PREFIX}/cache \
-    ${SMOKEPING_PREFIX}/var
-
-# Install container-specific config files
+# Layer 4: Container config (rebuilds only on config changes)
 COPY container/smokeping-config ${SMOKEPING_PREFIX}/etc/config
 COPY container/lighttpd.conf /etc/lighttpd/lighttpd.conf
 COPY container/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-# Clean up build directory
-RUN rm -rf /build
 
 EXPOSE 4265
 

--- a/container-run.sh
+++ b/container-run.sh
@@ -3,12 +3,15 @@ set -e
 
 IMAGE_NAME="smokeping"
 CONTAINER_NAME="smokeping"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 usage() {
-    echo "Usage: $0 [build|run|stop|clean]"
+    echo "Usage: $0 [build|run|dev|stop|clean]"
     echo ""
     echo "  build   Build the container image (auto-cleans old images)"
     echo "  run     Run the container (build first if needed)"
+    echo "  dev     Run with live-mounted htdocs, config, and lighttpd.conf"
+    echo "          (edit files locally, reload browser to see changes)"
     echo "  stop    Stop the running container"
     echo "  clean   Stop and remove container + all images"
     echo ""
@@ -28,40 +31,84 @@ prune_old_images() {
 
 do_build() {
     echo "Building ${IMAGE_NAME} container..."
-    podman build -t "${IMAGE_NAME}" .
+    podman build -t "${IMAGE_NAME}" "${SCRIPT_DIR}"
     prune_old_images
 }
 
-do_run() {
-    local port="${SMOKEPING_PORT:-4265}"
-
-    # Stop old container if running
+stop_existing() {
     if podman container exists "${CONTAINER_NAME}" 2>/dev/null; then
         echo "Stopping existing ${CONTAINER_NAME}..."
         podman stop "${CONTAINER_NAME}" 2>/dev/null || true
         podman rm "${CONTAINER_NAME}" 2>/dev/null || true
     fi
+}
 
-    # Build if image doesn't exist
+do_run() {
+    local port="${SMOKEPING_PORT:-4265}"
+    stop_existing
+
     if ! podman image exists "${IMAGE_NAME}"; then
         do_build
     fi
 
     local run_args=(
         --name "${CONTAINER_NAME}"
-        -p "${port}:4265"
+        -p "0.0.0.0:${port}:4265"
         --cap-add=NET_RAW
         --rm
     )
 
-    # Optional: persistent data volume
     if [ -n "${SMOKEPING_DATA}" ]; then
         mkdir -p "${SMOKEPING_DATA}"
         run_args+=(-v "${SMOKEPING_DATA}:/opt/smokeping/data")
     fi
 
     echo "Starting ${CONTAINER_NAME} on port ${port}..."
-    echo "Web UI: http://localhost:${port}/smokeping.cgi"
+    echo "Web UI: http://localhost:${port}/"
+    podman run "${run_args[@]}" "${IMAGE_NAME}"
+}
+
+do_dev() {
+    local port="${SMOKEPING_PORT:-4265}"
+    stop_existing
+
+    if ! podman image exists "${IMAGE_NAME}"; then
+        do_build
+    fi
+
+    local run_args=(
+        --name "${CONTAINER_NAME}"
+        -p "0.0.0.0:${port}:4265"
+        --cap-add=NET_RAW
+        --rm
+        # Live-mount: edit locally, reload browser
+        -v "${SCRIPT_DIR}/htdocs/css:/opt/smokeping/htdocs/css:ro"
+        -v "${SCRIPT_DIR}/htdocs/js:/opt/smokeping/htdocs/js:ro"
+        -v "${SCRIPT_DIR}/htdocs/img:/opt/smokeping/htdocs/img:ro"
+        -v "${SCRIPT_DIR}/etc/basepage.html.dist:/opt/smokeping/etc/basepage.html.dist:ro"
+        -v "${SCRIPT_DIR}/container/smokeping-config:/opt/smokeping/etc/config:ro"
+        -v "${SCRIPT_DIR}/container/lighttpd.conf:/etc/lighttpd/lighttpd.conf:ro"
+    )
+
+    if [ -n "${SMOKEPING_DATA}" ]; then
+        mkdir -p "${SMOKEPING_DATA}"
+        run_args+=(-v "${SMOKEPING_DATA}:/opt/smokeping/data")
+    fi
+
+    echo "Starting ${CONTAINER_NAME} in DEV mode on port ${port}..."
+    echo "Web UI: http://localhost:${port}/"
+    echo ""
+    echo "Live-mounted (edit + reload browser):"
+    echo "  htdocs/css/          -> /opt/smokeping/htdocs/css/"
+    echo "  htdocs/js/           -> /opt/smokeping/htdocs/js/"
+    echo "  htdocs/img/          -> /opt/smokeping/htdocs/img/"
+    echo "  etc/basepage.html.dist -> /opt/smokeping/etc/basepage.html.dist"
+    echo "  container/smokeping-config -> /opt/smokeping/etc/config"
+    echo "  container/lighttpd.conf    -> /etc/lighttpd/lighttpd.conf"
+    echo ""
+    echo "Note: lighttpd.conf changes require container restart (stop + dev)"
+    echo "      SmokePing config changes require container restart"
+    echo "      CSS/JS/HTML changes are instant (just reload browser)"
     podman run "${run_args[@]}" "${IMAGE_NAME}"
 }
 
@@ -80,6 +127,7 @@ do_clean() {
 case "${1:-run}" in
     build) do_build ;;
     run)   do_run ;;
+    dev)   do_dev ;;
     stop)  do_stop ;;
     clean) do_clean ;;
     *)     usage; exit 1 ;;

--- a/container-run.sh
+++ b/container-run.sh
@@ -7,23 +7,46 @@ CONTAINER_NAME="smokeping"
 usage() {
     echo "Usage: $0 [build|run|stop|clean]"
     echo ""
-    echo "  build   Build the container image"
+    echo "  build   Build the container image (auto-cleans old images)"
     echo "  run     Run the container (build first if needed)"
     echo "  stop    Stop the running container"
-    echo "  clean   Stop and remove container + image"
+    echo "  clean   Stop and remove container + all images"
     echo ""
     echo "Environment variables:"
-    echo "  SMOKEPING_PORT  Host port to map (default: 8080)"
+    echo "  SMOKEPING_PORT  Host port to map (default: 4265)"
     echo "  SMOKEPING_DATA  Host path for RRD data persistence (optional)"
+}
+
+prune_old_images() {
+    local dangling
+    dangling=$(podman images --filter "dangling=true" -q 2>/dev/null)
+    if [ -n "$dangling" ]; then
+        echo "Removing dangling images..."
+        podman image prune -f >/dev/null
+    fi
 }
 
 do_build() {
     echo "Building ${IMAGE_NAME} container..."
     podman build -t "${IMAGE_NAME}" .
+    prune_old_images
 }
 
 do_run() {
     local port="${SMOKEPING_PORT:-4265}"
+
+    # Stop old container if running
+    if podman container exists "${CONTAINER_NAME}" 2>/dev/null; then
+        echo "Stopping existing ${CONTAINER_NAME}..."
+        podman stop "${CONTAINER_NAME}" 2>/dev/null || true
+        podman rm "${CONTAINER_NAME}" 2>/dev/null || true
+    fi
+
+    # Build if image doesn't exist
+    if ! podman image exists "${IMAGE_NAME}"; then
+        do_build
+    fi
+
     local run_args=(
         --name "${CONTAINER_NAME}"
         -p "${port}:4265"
@@ -35,11 +58,6 @@ do_run() {
     if [ -n "${SMOKEPING_DATA}" ]; then
         mkdir -p "${SMOKEPING_DATA}"
         run_args+=(-v "${SMOKEPING_DATA}:/opt/smokeping/data")
-    fi
-
-    # Build if image doesn't exist
-    if ! podman image exists "${IMAGE_NAME}"; then
-        do_build
     fi
 
     echo "Starting ${CONTAINER_NAME} on port ${port}..."
@@ -54,8 +72,9 @@ do_stop() {
 
 do_clean() {
     do_stop
-    echo "Removing image ${IMAGE_NAME}..."
+    echo "Removing image ${IMAGE_NAME} and dangling images..."
     podman rmi "${IMAGE_NAME}" 2>/dev/null || true
+    podman image prune -f >/dev/null 2>&1 || true
 }
 
 case "${1:-run}" in

--- a/container-run.sh
+++ b/container-run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="smokeping"
+CONTAINER_NAME="smokeping"
+
+usage() {
+    echo "Usage: $0 [build|run|stop|clean]"
+    echo ""
+    echo "  build   Build the container image"
+    echo "  run     Run the container (build first if needed)"
+    echo "  stop    Stop the running container"
+    echo "  clean   Stop and remove container + image"
+    echo ""
+    echo "Environment variables:"
+    echo "  SMOKEPING_PORT  Host port to map (default: 8080)"
+    echo "  SMOKEPING_DATA  Host path for RRD data persistence (optional)"
+}
+
+do_build() {
+    echo "Building ${IMAGE_NAME} container..."
+    podman build -t "${IMAGE_NAME}" .
+}
+
+do_run() {
+    local port="${SMOKEPING_PORT:-4265}"
+    local run_args=(
+        --name "${CONTAINER_NAME}"
+        -p "${port}:4265"
+        --cap-add=NET_RAW
+        --rm
+    )
+
+    # Optional: persistent data volume
+    if [ -n "${SMOKEPING_DATA}" ]; then
+        mkdir -p "${SMOKEPING_DATA}"
+        run_args+=(-v "${SMOKEPING_DATA}:/opt/smokeping/data")
+    fi
+
+    # Build if image doesn't exist
+    if ! podman image exists "${IMAGE_NAME}"; then
+        do_build
+    fi
+
+    echo "Starting ${CONTAINER_NAME} on port ${port}..."
+    echo "Web UI: http://localhost:${port}/smokeping.cgi"
+    podman run "${run_args[@]}" "${IMAGE_NAME}"
+}
+
+do_stop() {
+    echo "Stopping ${CONTAINER_NAME}..."
+    podman stop "${CONTAINER_NAME}" 2>/dev/null || true
+}
+
+do_clean() {
+    do_stop
+    echo "Removing image ${IMAGE_NAME}..."
+    podman rmi "${IMAGE_NAME}" 2>/dev/null || true
+}
+
+case "${1:-run}" in
+    build) do_build ;;
+    run)   do_run ;;
+    stop)  do_stop ;;
+    clean) do_clean ;;
+    *)     usage; exit 1 ;;
+esac

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+SMOKEPING_PREFIX=/opt/smokeping
+
+# Ensure data directories exist
+mkdir -p "${SMOKEPING_PREFIX}/data" "${SMOKEPING_PREFIX}/cache" "${SMOKEPING_PREFIX}/var"
+
+echo "Starting SmokePing daemon..."
+"${SMOKEPING_PREFIX}/bin/smokeping" \
+    --config="${SMOKEPING_PREFIX}/etc/config" \
+    --nodaemon \
+    --logfile=stdout &
+
+SMOKEPING_PID=$!
+
+echo "Starting lighttpd on port 4265..."
+lighttpd -D -f /etc/lighttpd/lighttpd.conf &
+LIGHTTPD_PID=$!
+
+# Shut down cleanly on SIGTERM/SIGINT
+trap "kill $SMOKEPING_PID $LIGHTTPD_PID 2>/dev/null; wait; exit 0" SIGTERM SIGINT
+
+echo "SmokePing is running. Web UI: http://localhost:4265/"
+
+# Wait for either process to exit
+wait -n
+exit $?

--- a/container/lighttpd.conf
+++ b/container/lighttpd.conf
@@ -1,0 +1,37 @@
+server.document-root = "/opt/smokeping/htdocs"
+server.port = 4265
+server.bind = "0.0.0.0"
+
+# Required modules
+server.modules = (
+    "mod_cgi",
+    "mod_alias",
+)
+
+# MIME types
+mimetype.assign = (
+    ".html" => "text/html",
+    ".css"  => "text/css",
+    ".js"   => "application/javascript",
+    ".png"  => "image/png",
+    ".gif"  => "image/gif",
+    ".jpg"  => "image/jpeg",
+    ".svg"  => "image/svg+xml",
+)
+
+# Index file
+index-file.names = ( "index.html" )
+
+# CGI configuration
+cgi.assign = ( ".cgi" => "/usr/bin/perl" )
+
+# Serve SmokePing CGI
+alias.url = (
+    "/smokeping.cgi" => "/opt/smokeping/bin/smokeping_cgi",
+    "/cache"         => "/opt/smokeping/cache",
+)
+
+# Allow CGI execution for smokeping binary
+$HTTP["url"] =~ "^/smokeping.cgi" {
+    cgi.assign = ( "" => "/usr/bin/perl" )
+}

--- a/container/lighttpd.conf
+++ b/container/lighttpd.conf
@@ -6,6 +6,7 @@ server.bind = "0.0.0.0"
 server.modules = (
     "mod_cgi",
     "mod_alias",
+    "mod_redirect",
 )
 
 # MIME types
@@ -35,3 +36,8 @@ alias.url = (
 $HTTP["url"] =~ "^/smokeping.cgi" {
     cgi.assign = ( "" => "/usr/bin/perl" )
 }
+
+# Redirect / to smokeping.cgi
+url.redirect = (
+    "^/$" => "/smokeping.cgi",
+)

--- a/container/smokeping-config
+++ b/container/smokeping-config
@@ -1,0 +1,291 @@
+*** General ***
+
+owner    = SmokePing
+contact  = admin@localhost
+mailhost = localhost
+# NOTE: do not put the Image Cache below cgi-bin
+imgcache = /opt/smokeping/cache
+imgurl   = cache
+datadir  = /opt/smokeping/data
+piddir   = /opt/smokeping/var
+cgiurl   = http://localhost:4265/smokeping.cgi
+smokemail = /opt/smokeping/etc/smokemail.dist
+tmail = /opt/smokeping/etc/tmail.dist
+syslogfacility = local0
+
+*** Alerts ***
+to = admin@localhost
+from = smokeping@localhost
+
++someloss
+type = loss
+pattern = >0%,*12*,>0%,*12*,>0%
+comment = loss 3 times in a row
+
++highlatency
+type = rtt
+pattern = >200,>200,>200
+comment = high latency 3 times in a row
+
++packetloss
+type = loss
+pattern = ==0%,==0%,==0%,==0%,>20%,>20%,>20%
+comment = sudden packet loss after stability
+
+*** Database ***
+
+step     = 300
+pings    = 20
+
+AVERAGE  0.5   1  28800
+AVERAGE  0.5  12   9600
+    MIN  0.5  12   9600
+    MAX  0.5  12   9600
+AVERAGE  0.5 144   2400
+    MAX  0.5 144   2400
+    MIN  0.5 144   2400
+
+*** Presentation ***
+
+template = /opt/smokeping/etc/basepage.html.dist
+htmltitle = yes
+graphborders = no
+
++ charts
+
+menu = Charts
+title = The most interesting destinations
+
+++ stddev
+sorter = StdDev(entries=>4)
+title = Top Standard Deviation
+menu = Std Deviation
+format = Standard Deviation %f
+
+++ max
+sorter = Max(entries=>5)
+title = Top Max Roundtrip Time
+menu = by Max
+format = Max Roundtrip Time %f seconds
+
+++ loss
+sorter = Loss(entries=>5)
+title = Top Packet Loss
+menu = Loss
+format = Packets Lost %f
+
+++ median
+sorter = Median(entries=>5)
+title = Top Median Roundtrip Time
+menu = by Median
+format = Median RTT %f seconds
+
++ overview
+
+width = 600
+height = 50
+range = 10h
+
++ detail
+
+width = 600
+height = 200
+unison_tolerance = 2
+
+"Last 3 Hours"    3h
+"Last 30 Hours"   30h
+"Last 10 Days"    10d
+"Last 360 Days"   360d
+
+*** Probes ***
+
++ FPing
+
+binary = /usr/bin/fping
+
++ DNS
+binary = /usr/bin/dig
+lookup = smtp.gmail.com
+
+*** Targets ***
+
+probe = FPing
+
+menu = Top
+title = Network Latency Grapher
+remark = SmokePing Demo - monitoring network latency across the globe
+
++ Local
+
+menu = Local
+title = Local Network
+
+++ Localhost
+menu = Localhost
+title = Localhost Loopback
+host = localhost
+
++ DNS_Resolvers
+
+menu = DNS Resolvers
+title = Public DNS Resolvers
+
+++ GooglePrimary
+menu = Google 8.8.8.8
+title = Google Public DNS (Primary)
+host = 8.8.8.8
+
+++ GoogleSecondary
+menu = Google 8.8.4.4
+title = Google Public DNS (Secondary)
+host = 8.8.4.4
+
+++ CloudflarePrimary
+menu = Cloudflare 1.1.1.1
+title = Cloudflare DNS (Primary)
+host = 1.1.1.1
+
+++ CloudflareSecondary
+menu = Cloudflare 1.0.0.1
+title = Cloudflare DNS (Secondary)
+host = 1.0.0.1
+
+++ Quad9
+menu = Quad9 9.9.9.9
+title = Quad9 DNS
+host = 9.9.9.9
+
+++ OpenDNS
+menu = OpenDNS
+title = Cisco OpenDNS
+host = 208.67.222.222
+
++ CloudProviders
+
+menu = Cloud Providers
+title = Major Cloud Providers
+
+++ AWS
+menu = AWS
+title = Amazon Web Services
+host = ec2.amazonaws.com
+
+++ Azure
+menu = Azure
+title = Microsoft Azure
+host = azure.microsoft.com
+
+++ GCP
+menu = Google Cloud
+title = Google Cloud Platform
+host = cloud.google.com
+
+++ Hetzner
+menu = Hetzner
+title = Hetzner Cloud
+host = www.hetzner.com
+
+++ DigitalOcean
+menu = DigitalOcean
+title = DigitalOcean
+host = www.digitalocean.com
+
++ Europe
+
+menu = Europe
+title = European Targets
+
+++ SwitchCH
+menu = SWITCH (CH)
+title = SWITCH - Swiss Education Network
+host = www.switch.ch
+
+++ DENIC
+menu = DENIC (DE)
+title = DENIC - German Domain Registry
+host = www.denic.de
+
+++ RIPE
+menu = RIPE NCC
+title = RIPE Network Coordination Centre
+host = www.ripe.net
+
+++ BBC
+menu = BBC (UK)
+title = BBC United Kingdom
+host = www.bbc.co.uk
+
+++ LeMonde
+menu = Le Monde (FR)
+title = Le Monde France
+host = www.lemonde.fr
+
++ NorthAmerica
+
+menu = North America
+title = North American Targets
+
+++ MIT
+menu = MIT
+title = Massachusetts Institute of Technology
+host = web.mit.edu
+
+++ Stanford
+menu = Stanford
+title = Stanford University
+host = www.stanford.edu
+
+++ NASA
+menu = NASA
+title = NASA
+host = www.nasa.gov
+
+++ GitHub
+menu = GitHub
+title = GitHub
+host = github.com
+
++ AsiaPacific
+
+menu = Asia Pacific
+title = Asia Pacific Targets
+
+++ NII_Japan
+menu = NII (JP)
+title = National Institute of Informatics Japan
+host = www.nii.ac.jp
+
+++ AARNet
+menu = AARNet (AU)
+title = Australian Academic Research Network
+host = www.aarnet.edu.au
+
+++ KRNIC
+menu = KRNIC (KR)
+title = Korea Network Information Center
+host = www.nic.or.kr
+
++ CDN
+
+menu = CDN / Services
+title = Content Delivery & Web Services
+
+++ Akamai
+menu = Akamai
+title = Akamai CDN
+host = www.akamai.com
+
+++ Fastly
+menu = Fastly
+title = Fastly CDN
+host = www.fastly.com
+
+++ Wikipedia
+menu = Wikipedia
+title = Wikipedia
+host = www.wikipedia.org
+
+++ StackOverflow
+menu = StackOverflow
+title = Stack Overflow
+host = stackoverflow.com

--- a/htdocs/css/smokeping-screen.css
+++ b/htdocs/css/smokeping-screen.css
@@ -330,9 +330,10 @@ a#menu-button svg {
 
 .main .panel,
 .main .panel-no-border {
-	margin: 6px;
-	display: inline-block;
-	vertical-align: top;
+	margin: 6px 0;
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .main .panel {
@@ -370,6 +371,18 @@ a#menu-button svg {
 
 .main .panel-body {
 	padding: 8px;
+	overflow: hidden;
+}
+
+/* All graph images scale to panel width, overriding HTML width/height attributes */
+.main .panel-body img,
+.main .panel-body svg,
+.overview img,
+.details img {
+	max-width: 100%;
+	width: 100% !important;
+	height: auto !important;
+	display: block;
 }
 
 /* ── Overview & Details containers ───────────────────── */
@@ -418,7 +431,7 @@ a#menu-button svg {
 
 .sidebar-hidden .main,
 .sidebar-hidden .footer {
-	padding-left: 0 !important;
+	padding-left: 20px !important;
 }
 
 .sidebar-hidden .navbar {
@@ -442,9 +455,10 @@ a#menu-button svg {
 	}
 
 	.main {
-		padding-left: 0;
+		padding-left: 20px;
 		margin-left: 0;
-		width: calc(100% - 40px);
+		width: 100%;
+		box-sizing: border-box;
 	}
 
 	.footer {
@@ -462,9 +476,11 @@ a#menu-button svg {
 
 /* ── Misc ─────────────────────────────────────────────── */
 
-.img-responsive {
+.img-responsive,
+img[src$=".svg"] {
 	max-width: 100%;
 	height: auto;
+	display: block;
 }
 
 /* --- Modern enhancements (backward compatible) --- */

--- a/htdocs/css/smokeping-screen.css
+++ b/htdocs/css/smokeping-screen.css
@@ -77,6 +77,7 @@ img {
 	display: flex;
 	flex-direction: column;
 	z-index: 200;
+	transition: left var(--transition);
 }
 
 .sidebar-header {
@@ -162,7 +163,9 @@ img {
 }
 
 .sidebar .filter-text input:focus {
+	background-color: var(--sidebar-bg);
 	border-color: var(--sidebar-accent);
+	outline: 1px solid var(--sidebar-accent);
 }
 
 /* ── Sidebar nav menu ─────────────────────────────────── */
@@ -233,6 +236,7 @@ img {
 	display: flex;
 	align-items: center;
 	z-index: 100;
+	transition: left var(--transition);
 }
 
 .navbar .navbar-menu {
@@ -402,6 +406,8 @@ a#menu-button svg {
 	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: 4px;
+	clear: both;
+	transition: padding-left var(--transition);
 }
 
 .footer p {
@@ -441,11 +447,6 @@ a#menu-button svg {
 /* ── Responsive ───────────────────────────────────────── */
 
 @media (max-width: 900px) {
-	.sidebar,
-	.navbar {
-		transition: left var(--transition);
-	}
-
 	.sidebar {
 		left: calc(0px - var(--sidebar-width));
 	}
@@ -476,94 +477,31 @@ a#menu-button svg {
 
 /* ── Misc ─────────────────────────────────────────────── */
 
-.img-responsive,
-img[src$=".svg"] {
-	max-width: 100%;
-	height: auto;
-	display: block;
-}
-
-/* --- Modern enhancements (backward compatible) --- */
-
-/* Smooth transitions for interactive elements */
-.sidebar ul.menu li {
-	transition: background 0.15s ease, border-color 0.15s ease;
-}
-.sidebar ul.menu li a {
-	transition: color 0.15s ease;
-}
-
-/* Rounded panels */
-.main .panel {
-	border-radius: 4px;
-	overflow: hidden;
-}
-.main .panel-heading {
-	border-radius: 4px 4px 0 0;
-}
-
-/* Better filter input styling */
-.sidebar .filter-text input {
-	transition: background-color 0.2s ease;
-}
-.sidebar .filter-text input:focus {
-	background-color: #1a1a1a;
-	outline: 1px solid #67c2ef;
-}
-
-/* Navbar transition for mobile toggle */
-.navbar {
-	transition: left 0.4s ease;
-}
-
-/* Improved footer spacing */
-.footer {
-	transition: padding-left 0.4s ease;
-	clear: both;
-	padding-top: 5px;
-	padding-bottom: 5px;
-}
-
-/* Cropper (zoom) area styling */
 .imgCrop_clickArea {
 	cursor: crosshair;
 }
 
-/* Dark mode support */
+/* ── Dark mode ───────────────────────────────────────── */
+
 @media (prefers-color-scheme: dark) {
-	body {
-		background: #1a1a2e;
-		color: #e0e0e0;
-	}
-	.sidebar {
-		background: #16213e;
-		border-right: 1px solid #0f3460;
-	}
-	.sidebar-header {
-		border-bottom-color: #0f3460;
-	}
-	.sidebar .filter-text input {
-		background-color: #0f3460;
-		color: #e0e0e0;
-	}
-	.sidebar ul.menu li.menuopen,
-	.sidebar ul.menu li:hover,
-	.sidebar ul.menu li.menuactive {
-		border-color: #0f3460;
-		background: #0a1628;
-	}
-	.sidebar ul.menu li ul {
-		background: #0a1628;
-	}
-	.navbar {
-		background: linear-gradient(#1a1a2e, #16213e);
-		border-bottom-color: #0f3460;
-		text-shadow: none;
-	}
-	.navbar .navbar-menu,
-	.navbar .navbar-refresh,
-	.navbar .navbar-user {
-		border-color: #0f3460;
+	:root {
+		--sidebar-bg: #16213e;
+		--sidebar-hover: #0a1628;
+		--sidebar-active: #0a1628;
+		--sidebar-border: #0f3460;
+		--sidebar-text: #b0b8d1;
+		--sidebar-text-active: #ffffff;
+		--sidebar-accent: #4f9cf9;
+		--navbar-bg: #1a1a2e;
+		--navbar-border: #0f3460;
+		--body-bg: #1a1a2e;
+		--panel-bg: #16213e;
+		--panel-border: #0f3460;
+		--panel-header-bg: #1a1a2e;
+		--text-primary: #e0e0e0;
+		--text-muted: #8a8a8a;
+		--shadow-sm: 0 2px 4px rgba(0,0,0,0.3);
+		--shadow-md: 0 4px 8px rgba(0,0,0,0.4);
 	}
 	a#menu-button {
 		filter: invert(1);
@@ -571,29 +509,6 @@ img[src$=".svg"] {
 	.navbar .navbar-user .icon-person {
 		filter: invert(1);
 		opacity: 0.7;
-	}
-	.main .panel {
-		background: #16213e;
-		border-color: #0f3460;
-		box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-	}
-	.main .panel-heading {
-		background: #1a1a2e;
-		border-bottom-color: #0f3460;
-		box-shadow: none;
-	}
-	.main .panel-heading h2,
-	.main .panel-heading-no-border h2 {
-		color: #e0e0e0;
-	}
-	.footer {
-		border-top-color: #0f3460;
-	}
-	.footer, .footer a {
-		color: #8a8a8a;
-	}
-	a#refresh-button {
-		color: #e0e0e0;
 	}
 }
 

--- a/htdocs/js/smokeping.js
+++ b/htdocs/js/smokeping.js
@@ -134,7 +134,66 @@ if($('range_form') != null && $('range_form').length){
     }));
 }
 
-Event.observe( 
+// ── Dynamic graph width ────────────────────────────────
+(function () {
+    var resizeTimer;
+    var PADDING = 18;        // panel-body padding (8px each side) + border slack
+    var MIN_WIDTH = 200;
+    var MAX_WIDTH = 3000;
+
+    function clamp(w) {
+        return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, w));
+    }
+
+    function getContentWidth() {
+        var panel = document.querySelector('.main .panel-body');
+        if (panel) return panel.clientWidth - PADDING;
+        var main = document.querySelector('.main');
+        if (main) return main.clientWidth - 40; // 20px padding each side
+        return 0;
+    }
+
+    function currentUrlWidth() {
+        var m = location.search.match(/[?&]width=(\d+)/);
+        return m ? parseInt(m[1], 10) : 0;
+    }
+
+    function buildWidthUrl(w) {
+        var url = location.href;
+        if (/[?&]width=\d+/.test(url)) {
+            return url.replace(/([?&]width=)\d+/, '$1' + w);
+        }
+        return url + (url.indexOf('?') === -1 ? '?' : '&') + 'width=' + w;
+    }
+
+    function recordWidth() {
+        var w = clamp(getContentWidth());
+        if (w <= 0) return;
+        if (history.replaceState) {
+            history.replaceState(null, '', buildWidthUrl(w));
+        }
+    }
+
+    // First visit without width param: reload once so server generates
+    // graphs at the correct size. On subsequent loads width is already set.
+    var w = clamp(getContentWidth());
+    if (w > 0 && currentUrlWidth() === 0) {
+        var imgs = document.querySelectorAll('.panel-body img, .panel-body svg');
+        for (var i = 0; i < imgs.length; i++) {
+            imgs[i].style.display = 'none';
+        }
+        location.replace(buildWidthUrl(w));
+    }
+
+    // On resize: just update the URL, SVGs scale via CSS.
+    // The next auto-refresh will regenerate at the correct width.
+    Event.observe(window, 'resize', function () {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(recordWidth, 500);
+    });
+})();
+
+Event.observe(
     window,
     'load',
     function() {

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -75,7 +75,7 @@ use Smokeping::Examples;
 use Smokeping::RRDtools;
 
 # global persistent variables for speedy
-use vars qw($cfg $probes $VERSION $havegetaddrinfo $cgimode);
+our ($cfg, $probes, $VERSION, $havegetaddrinfo, $cgimode);
 
 $VERSION="2.006000";
 
@@ -241,24 +241,24 @@ sub update_dynaddr ($$){
     my $prevaddress = "?";
     my $snmp = snmpget_ident $address;
     if (-r "$file.adr" and not -z "$file.adr"){
-        open(D, "<$file.adr")
+        open(my $adr_fh, '<', "$file.adr")
           or return "Error opening $file.adr: $!\n";
-        chomp($prevaddress = <D>);
-        close D;
+        chomp($prevaddress = <$adr_fh>);
+        close $adr_fh;
     }
 
     if ( $prevaddress ne $address){
-        open(D, ">$file.adr.new")
+        open(my $adr_out, '>', "$file.adr.new")
           or return "Error writing $file.adr.new: $!";
-        print D $address,"\n";
-        close D;
+        print $adr_out $address,"\n";
+        close $adr_out;
         rename "$file.adr.new","$file.adr";
     }
     if ( $snmp ) {
-        open (D, ">$file.snmp.new")
+        open(my $snmp_fh, '>', "$file.snmp.new")
           or return "Error writing $file.snmp.new: $!";
-        print D $snmp,"\n";
-        close D;
+        print $snmp_fh $snmp,"\n";
+        close $snmp_fh;
         rename "$file.snmp.new", "$file.snmp";
     } elsif ( -f "$file.snmp") { unlink "$file.snmp" };
 
@@ -279,9 +279,9 @@ sub sendmail ($$$){
         $smtp->dataend();
         $smtp->quit;
     } elsif ($cfg->{General}{sendmail} or -x "/usr/lib/sendmail"){
-        open (M, "|-") || exec (($cfg->{General}{sendmail} || "/usr/lib/sendmail"),"-f",$from,$to);
-        print M $body;
-        close M;
+        open(my $mail_fh, '|-') || exec (($cfg->{General}{sendmail} || "/usr/lib/sendmail"),"-f",$from,$to);
+        print $mail_fh $body;
+        close $mail_fh;
     } else {
         warn "ERROR: not sending mail to $to, as all methods failed\n";
     }
@@ -654,32 +654,32 @@ sub enable_dynamic($$$$){
             $usepath =~ s/\.$//;
             my $secret = int(rand 1000000);
             my $md5 = md5_base64($secret);
-            open C, "<$cfgfile" or die "ERROR: Reading $cfgfile: $!\n";
-            open G, ">$cfgfile.new" or die "ERROR: Writing $cfgfile.new: $!\n";
+            open(my $cfg_fh, '<', $cfgfile) or die "ERROR: Reading $cfgfile: $!\n";
+            open(my $cfg_out, '>', "$cfgfile.new") or die "ERROR: Writing $cfgfile.new: $!\n";
             my $section ;
             my @goal = split /\./, $usepath;
             my $indent = "+";
             my $done;
-            while (<C>){
-                $done && do { print G; next };
+            while (<$cfg_fh>){
+                $done && do { print $cfg_out $_; next };
                 /^\s*\Q*** Targets ***\E\s*$/ && do{$section = 'match'};
                 @goal && $section && /^\s*\Q${indent}\E\s*\Q$goal[0]\E/ && do {
                     $indent .= "+";
                     shift @goal;
                 };
                 (not @goal) && /^\s*host\s*=\s*DYNAMIC$/ && do {
-                    print G "host = DYNAMIC/$md5\n";
+                    print $cfg_out "host = DYNAMIC/$md5\n";
                     $done = 1;
                     next;
                 };
-                print G;
+                print $cfg_out $_;
             }
-            close G;
+            close $cfg_out;
             rename "$cfgfile.new", $cfgfile;
-            close C;
+            close $cfg_fh;
             my $body;
-            open SMOKE, $cfg->{General}{smokemail} or die "ERROR: can't read $cfg->{General}{smokemail}: $!\n";
-            while (<SMOKE>){
+            open(my $smoke_fh, '<', $cfg->{General}{smokemail}) or die "ERROR: can't read $cfg->{General}{smokemail}: $!\n";
+            while (<$smoke_fh>){
                 s/<##PATH##>/$usepath/ig;
                 s/<##SECRET##>/$secret/ig;
                 s/<##URL##>/$cfg->{General}{cgiurl}/;
@@ -688,7 +688,7 @@ sub enable_dynamic($$$$){
                 s/<##TO##>/$email/;
                 $body .= $_;
             }
-            close SMOKE;
+            close $smoke_fh;
 
 
             my $mail;
@@ -827,9 +827,9 @@ sub fill_template ($$;$){
     if ($template){
         my $line = $/;
         undef $/;
-        open I, $template or return undef;
-        $data = <I>;
-        close I;
+        open(my $tmpl_fh, '<', $template) or return undef;
+        $data = <$tmpl_fh>;
+        close $tmpl_fh;
         $/ = $line;
     }
     foreach my $tag (keys %{$subst}) {
@@ -1236,20 +1236,20 @@ sub get_detail ($$$$;$){
         @tasks = @{$cfg->{Presentation}{detail}{_table}};
         for my $slave (@slaves){
             my $s =  $slave ? "~$slave" : "";
-            if (open (HG,"<${imgbase}.maxheight$s")){
-                 while (<HG>){
+            if (open(my $hg_fh, '<', "${imgbase}.maxheight$s")){
+                 while (<$hg_fh>){
                      chomp;
                      my @l = split / /;
                      $lastheight{$s}{$l[0]} = $l[1];
                  }
-                 close HG;
+                 close $hg_fh;
              }
              $max->{$s} = findmax $cfg, $base_rrd.$s.".rrd";
-             if (open (HG,">${imgbase}.maxheight$s")){
+             if (open(my $hg_out, '>', "${imgbase}.maxheight$s")){
                  foreach my $size (keys %{$max->{$s}}){
-                     print HG "$s $max->{$s}{$size}\n";
+                     print $hg_out "$s $max->{$s}{$size}\n";
                  }
-                 close HG;
+                 close $hg_out;
              }
         }
     }
@@ -2105,9 +2105,9 @@ Comment: $alert->{comment}
 
 XMPPALERT
                         if (-x "/usr/bin/sendxmpp"){
-                            open (M, "|-") || exec ("/usr/bin/sendxmpp $xmpparg");
-                            print M $xmppalert;
-                            close M;
+                            open(my $xmpp_fh, '|-') || exec ("/usr/bin/sendxmpp $xmpparg");
+                            print $xmpp_fh $xmppalert;
+                            close $xmpp_fh;
                         }
                         else {
                             warn "Command sendxmpp not found. Try 'apt-get install sendxmpp' to install it. xmpp message with arg line $xmpparg could not be sent";
@@ -2211,9 +2211,9 @@ sub update_rrds($$$$$$) {
                 my $s = $update->[0] ? "~".$update->[0] : "";
                 if ( $tree->{rawlog} ){
                         my $file =  POSIX::strftime $tree->{rawlog},localtime($update->[1]);
-                    if (open LOG,">>$name$s.$file.csv"){
-                            print LOG time,"\t",join("\t",split /:/,$update->[2]),"\n";
-                                close LOG;
+                    if (open(my $log_fh, '>>', "$name$s.$file.csv")){
+                            print $log_fh time,"\t",join("\t",split /:/,$update->[2]),"\n";
+                                close $log_fh;
                             } else {
                                 do_log "Warning: failed to open $name$s.$file for logging: $!\n";
                             }
@@ -4119,8 +4119,8 @@ sub kill_smoke ($$) {
   my $pidfile = shift;
   my $signal = shift;
     if (defined $pidfile){
-        if ( -f $pidfile && open PIDFILE, "<$pidfile" ) {
-            <PIDFILE> =~ /(\d+)/;
+        if ( -f $pidfile && open(my $pid_fh, '<', $pidfile) ) {
+            <$pid_fh> =~ /(\d+)/;
             my $pid = $1;
             if ($signal == SIGINT || $signal == SIGTERM) {
                 kill $signal, $pid if kill 0, $pid;
@@ -4132,7 +4132,7 @@ sub kill_smoke ($$) {
                         unless kill 0, $pid;
                 kill $signal, $pid;
             }
-            close PIDFILE;
+            close $pid_fh;
         } else {
             die "ERROR: Can not read pid from $pidfile: $!\n";
         };
@@ -4143,9 +4143,9 @@ sub daemonize_me ($) {
   my $pidfile = shift;
     if (defined $pidfile){
         if (-f $pidfile ) {
-            open PIDFILE, "<$pidfile";
-            <PIDFILE> =~ /(\d+)/;
-            close PIDFILE;
+            open(my $pid_fh, '<', $pidfile);
+            <$pid_fh> =~ /(\d+)/;
+            close $pid_fh;
             my $pid = $1;
             die "ERROR: I Quit! Another copy of $0 ($pid) seems to be running.\n".
               "       Check $pidfile\n"
@@ -4159,9 +4159,9 @@ sub daemonize_me ($) {
     if ($pid) {
         exit;
     } else {
-        if(open(PIDFILE,">$pidfile")){
-        print PIDFILE "$$\n";
-        close PIDFILE;
+        if(open(my $pid_fh, '>', $pidfile)){
+        print $pid_fh "$$\n";
+        close $pid_fh;
         } else {
           warn "creating $pidfile: $!\n";
         };
@@ -4248,9 +4248,9 @@ sub daemonize_me ($) {
         }
 
         sub do_filelog ($){
-                open X,">>$use_filelog" or return;
-                print X scalar localtime(time)," - ",shift,"\n";
-                close X;
+                open(my $log_fh, '>>', $use_filelog) or return;
+                print $log_fh scalar localtime(time)," - ",shift,"\n";
+                close $log_fh;
         }
 
         sub do_log (@){
@@ -4505,8 +4505,8 @@ sub gen_page  ($$$) {
 
     $name = @$open ? join('.', @$open) . ".html" : "index.html";
 
-    die "Can not open $cfg-{General}{pagedir}/$name for writing: $!" unless
-      open PAGEFILE, ">$cfg->{General}{pagedir}/$name";
+    open(my $page_fh, '>', "$cfg->{General}{pagedir}/$name")
+      or die "Can not open $cfg->{General}{pagedir}/$name for writing: $!";
 
     my $step = $probes->{$tree->{probe}}->step();
     my $readversion = "?";
@@ -4533,8 +4533,8 @@ sub gen_page  ($$$) {
           authuser => $authuser,
          });
 
-    print PAGEFILE $page || "<HTML><BODY>ERROR: Reading page template ".$cfg->{Presentation}{template}."</BODY></HTML>";
-    close PAGEFILE;
+    print $page_fh $page || "<HTML><BODY>ERROR: Reading page template ".$cfg->{Presentation}{template}."</BODY></HTML>";
+    close $page_fh;
 
     foreach my $key (keys %$tree) {
         my $value = $tree->{$key};
@@ -4575,9 +4575,9 @@ sub pages ($) {
 
 sub pod2man {
         my $string = shift;
-        my $pid = open(P, "-|");
+        my $pid = open(my $pod_fh, '-|');
         if ($pid) {
-                pod2usage(-verbose => 2, -input => \*P);
+                pod2usage(-verbose => 2, -input => $pod_fh);
                 exit 0;
         } else {
                 print $string;
@@ -5052,10 +5052,10 @@ sub gen_imgs ($){
   }
   if (not -r $cfg->{General}{imgcache}."/rrdtool.png" or
       (defined $modulemodtime and $modulemodtime > (stat _)[9])){
-open W, ">".$cfg->{General}{imgcache}."/rrdtool.png"
+open(my $img_fh, '>', $cfg->{General}{imgcache}."/rrdtool.png")
    or do { warn "WARNING: creating $cfg->{General}{imgcache}/rrdtool.png: $!\n"; return 0 };
-binmode W;
-print W unpack ('u', <<'UUENC');
+binmode $img_fh;
+print $img_fh unpack ('u', <<'UUENC');
 &B5!.1PT*
 "&@H`
 M````#4E(1%(```!D````'@@#````[85+P0```;Q03%1%3$Q,;8_U;I#X2TM+
@@ -5111,15 +5111,15 @@ M9P8`,"T)&R@)=!)'[**16D((T%J"DF2Y4$!0HK4`D10]0,Z++2+GCWX]L!.Q
 MX\]:K:KJN4UCI^)JQU.#GR^%0[/JJRL![FK)\HSC]T,P,_UJCF9?`'&L38BX
 /N=]>`````$E%3D2N0F""
 UUENC
-close W;
+close $img_fh;
 }
 
   if (not -r $cfg->{General}{imgcache}."/smokeping.png" or
       (defined $modulemodtime and $modulemodtime > (stat _)[9])){
-open W, ">".$cfg->{General}{imgcache}."/smokeping.png"
+open(my $img_fh, '>', $cfg->{General}{imgcache}."/smokeping.png")
    or do { warn "WARNING: creating $cfg->{General}{imgcache}/smokeping.png: $!\n"; return 0};
-binmode W;
-print W unpack ('u', <<'UUENC');
+binmode $img_fh;
+print $img_fh unpack ('u', <<'UUENC');
 &B5!.1PT*
 "&@H`
 M````#4E(1%(```!D````'@@#````[85+P0```A-03%1%3$Q,____3DY._W\`
@@ -5170,7 +5170,7 @@ M>>-_.0C1;-^Y\?0Z/;9F0]M:_?:VG1%L^H:V;5ADQX8-"];_-F0'%HE(0[U>
 M^FF,(MO7O5Z-;X0+([\+^4;T)R#<M`EJ%F"_`SFU\-M]N!EM"T]]6!O!_DX^
 5`F@QYX#.PQY?`````$E%3D2N0F""
 UUENC
-close W;
+close $img_fh;
 }
 }
 

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -84,7 +84,7 @@ my %opt;
 
 BEGIN {
   $havegetaddrinfo = 0;
-  eval 'use Socket6';
+  eval { require Socket6; Socket6->import() };
   $havegetaddrinfo = 1 unless $@;
 }
 
@@ -142,10 +142,12 @@ sub load_probe ($$$$) {
         # just in case, make sure we have the module loaded. unless
         # we are running as slave, this will already be the case
         # after reading the config file
-        eval 'require Smokeping::probes::'.$modname;
+        my $probeclass = "Smokeping::probes::$modname";
+        (my $probefile = $probeclass) =~ s|::|/|g;
+        eval { require "$probefile.pm" };
         die "$@\n" if $@;
         my $rv;
-        eval '$rv = Smokeping::probes::'.$modname.'->new( $properties,$cfg,$name);';
+        eval { $rv = $probeclass->new( $properties,$cfg,$name) };
         die "$@\n" if $@;
         die "Failed to load Probe $name (module $modname)\n" unless defined $rv;
         return $rv;
@@ -354,10 +356,14 @@ sub init_alerts ($){
             my $arg = $2;
             die "ERROR: matcher $matcher: all matchers start with a capital letter since version 2.0\n"
                 unless $matcher =~ /^[A-Z]/;
-            eval 'require Smokeping::matchers::'.$matcher;
+            my $matchclass = "Smokeping::matchers::$matcher";
+            (my $matchfile = $matchclass) =~ s|::|/|g;
+            eval { require "$matchfile.pm" };
             die "Matcher '$matcher' could not be loaded: $@\n" if $@;
             my $hand;
-            eval "\$hand = Smokeping::matchers::$matcher->new($arg)";
+            my @margs = eval "($arg)";
+            die "ERROR: Matcher '$matcher' could not parse arguments $arg:\n$@\n" if $@;
+            eval { $hand = $matchclass->new(@margs) };
             die "ERROR: Matcher '$matcher' could not be instantiated\nwith arguments $arg:\n$@\n" if $@;
             $x->{minlength} = $hand->Length;
             $x->{maxlength} = $x->{minlength};
@@ -864,6 +870,33 @@ sub brighten_webcolor {
     return Smokeping::Colorspace::rgb_to_web(@rgb);
 }
 
+sub get_param_width ($$) {
+    my $q = shift;
+    my $default = shift;
+    my $w = $q->param('width');
+    return $default unless defined $w and $w =~ /^\d+$/;
+    $w = int($w);
+    $w = 200  if $w < 200;
+    $w = 3000 if $w > 3000;
+    return $w;
+}
+
+# RRDtool --width sets the data area; the total image is wider due to
+# y-axis labels and margins (~97px).  Subtract this overhead so the
+# resulting SVG fits the browser container without img-responsive
+# scaling it down (which would shrink the text).
+sub get_rrd_width ($$) {
+    my $q = shift;
+    my $default = shift;
+    my $w = get_param_width($q, $default);
+    return $default if $w == $default;  # no URL override
+    my $rrd_overhead = 97;
+    $w = $w - $rrd_overhead;
+    $w = 200 if $w < 200;
+    return $w;
+}
+
+
 sub get_overview ($$$$){
     my $cfg = shift;
     my $q = shift;
@@ -1003,13 +1036,19 @@ sub get_overview ($$$$){
                   "GPRINT:avmsr$i:%5.1lf %s am/as\\l";
 
         }
+        # Scale overview time range proportionally with width
+        my $ov_range = exp2seconds($cfg->{Presentation}{overview}{range});
+        my $ov_default_w = $cfg->{Presentation}{overview}{width};
+        my $ov_actual_w = get_param_width($q, $ov_default_w);
+        $ov_range = int($ov_range * $ov_actual_w / $ov_default_w) if $ov_actual_w > $ov_default_w;
+
         my ($graphret,$xs,$ys) = RRDs::graph
           ($cfg->{General}{imgcache}.$dir."/${prop}_mini.svg",
     #       '--lazy',
-           '--start','-'.exp2seconds($cfg->{Presentation}{overview}{range}),
+           '--start','-'.$ov_range,
            '--title',$cfg->{Presentation}{htmltitle} ne 'yes' ? $phys_tree->{title} : '',
            '--height',$cfg->{Presentation}{overview}{height},
-           '--width',$cfg->{Presentation}{overview}{width},
+           '--width',get_rrd_width($q, $ov_default_w),
            '--vertical-label', $ProbeUnit,
            '--imgformat','SVG',
            Smokeping::Graphs::get_colors($cfg),
@@ -1029,8 +1068,8 @@ sub get_overview ($$$$){
                 $page .= "ERROR: $ERROR<br>".join("<br>", map {"'$_'"} @G);
         } else {
          $page.="<A HREF=\"".lnk($q, (join ".", @$open, ${prop}))."\">".
-            "<IMG ALT=\"\" WIDTH=\"$xs\" HEIGHT=\"$ys\" ".
-            "SRC=\"".$cfg->{General}{imgurl}.$dir."/${prop}_mini.svg\"></A>";
+            "<IMG ALT=\"\" class=\"img-responsive\" ".
+            "SRC=\"".$cfg->{General}{imgurl}.$dir."/${prop}_mini.svg?width=${ov_actual_w}\"></A>";
         }
         $page .="</div></div>\n";
     }
@@ -1360,10 +1399,20 @@ sub get_detail ($$$$;$){
         $end ||= 'last';
         $start = exp2seconds($start) if $mode =~ /[s]/;
 
-        my $startstr = $start =~ /^\d+$/ ? POSIX::strftime("%Y-%m-%d %H:%M",localtime($mode eq 'n' ? $start : time-$start)) : $start;
+        # Scale time range proportionally when display is wider than
+        # the configured default so that wider browsers show a longer
+        # time span instead of zooming into the same span.
+        my $display_start = $start;
+        if ($mode eq 's') {
+            my $default_w = $cfg->{Presentation}{detail}{width};
+            my $actual_w = get_param_width($q, $default_w);
+            $display_start = int($start * $actual_w / $default_w) if $actual_w > $default_w;
+        }
+
+        my $startstr = $display_start =~ /^\d+$/ ? POSIX::strftime("%Y-%m-%d %H:%M",localtime($mode eq 'n' ? $display_start : time-$display_start)) : $display_start;
         my $endstr   = $end =~ /^\d+$/ ? POSIX::strftime("%Y-%m-%d %H:%M",localtime($mode eq 'n' ? $end : time)) : $end;
 
-        my $realstart = ( $mode =~ /[sc]/ ? '-'.$start : $start);
+        my $realstart = ( $mode =~ /[sc]/ ? '-'.$display_start : $start);
 
         for my $slave (@slaves){
             my $s = $slave ? "~$slave" : "";
@@ -1463,7 +1512,7 @@ sub get_detail ($$$$;$){
                '--start',$realstart,
                ($end ne 'last' ? ('--end',$end) : ()),
                '--height',$cfg->{Presentation}{detail}{height},
-               '--width',$cfg->{Presentation}{detail}{width},
+               '--width',get_rrd_width($q, $cfg->{Presentation}{detail}{width}),
                '--title',$title,
                '--rigid',
                '--upper-limit', $max->{$s}{$start},
@@ -1557,15 +1606,17 @@ sub get_detail ($$$$;$){
                     $page .= "<div class=\"".panel_heading_class()."\"><h2>$title</h2></div>";
                 }
                 $page .= "<div class=\"panel-body\">";
+                my $svg_w = get_param_width($q, $cfg->{Presentation}{detail}{width});
                 $page .= ( qq{<a href="}.cgiurl($q,$cfg)."?".hierarchy($q).qq{displaymode=n&start=$startstr&end=now&}."target=".$t.$s.'">'
-                      . qq{<IMG ALT="" SRC="${imghref}${s}_${end}_${start}.svg">}."</a>" ); #"
+                      . qq{<IMG ALT="" SRC="${imghref}${s}_${end}_${start}.svg?width=${svg_w}" class="img-responsive">}."</a>" ); #"
                 $page .= "</div></div>\n";
             }
         } else { # chart mode
             $page .= qq{<div class="panel-body">};
             my $href= (split /~/, (join ".", @$open))[0]; #/ # the link is 'slave free'
+            my $svg_w = get_param_width($q, $cfg->{Presentation}{detail}{width});
             $page .= (  qq{<a href="}.lnk($q, $href).qq{">}
-                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg">}."</a>" ); #"
+                      . qq{<IMG ALT="" SRC="${imghref}_${end}_${start}.svg?width=${svg_w}" class="img-responsive">}."</a>" ); #"
             $page .= "</div>";
 
         }
@@ -1868,9 +1919,13 @@ sub load_sorters($){
         my $arg = $2;
         die "ERROR: sorter $sorter: all sorters start with a capital letter\n"
             unless $sorter =~ /^[A-Z]/;
-        eval 'require Smokeping::sorters::'.$sorter;
+        my $sortclass = "Smokeping::sorters::$sorter";
+        (my $sortfile = $sortclass) =~ s|::|/|g;
+        eval { require "$sortfile.pm" };
         die "Sorter '$sorter' could not be loaded: $@\n" if $@;
-        $x->{__obj} = eval "Smokeping::sorters::$sorter->new($arg)";
+        my @sargs = eval "($arg)";
+        die "ERROR: sorter $sorter: could not parse arguments $arg: $@\n" if $@;
+        $x->{__obj} = eval { $sortclass->new(@sargs) };
         die "ERROR: sorter $sorter: instantiation with Smokeping::sorters::$sorter->new($arg): $@\n"
            if $@;
     }
@@ -4143,7 +4198,7 @@ sub daemonize_me ($) {
                 # so trap this inside 'eval'
                 # even this apparently isn't enough for older versions that try to
                 # find out whether they are inside an eval...oh well.
-                eval 'CGI::Carp::set_progname($0 . " [client " . ($ENV{REMOTE_ADDR}||"(unknown)") . "]")';
+                eval { CGI::Carp::set_progname($0 . " [client " . ($ENV{REMOTE_ADDR}||"(unknown)") . "]") };
         }
 
         sub initialize_filelog ($){
@@ -4531,7 +4586,7 @@ sub pod2man {
 }
 
 sub maybe_require {
-        # like eval "require $class", but tries to
+        # like require $file, but tries to
         # fake missing classes by adding them to %INC.
         # This rocks when we're building the documentation
         # so we don't need to have the external modules
@@ -4539,20 +4594,20 @@ sub maybe_require {
 
         my $class = shift;
 
+        my $file = $class;
+        $file =~ s,::,/,g;
+        $file .= ".pm";
+
         # don't do the kludge unless we're building documentation
         unless (exists $opt{makepod} or exists $opt{man}) {
-                eval "require $class";
+                eval { require $file };
                 die  "require $class failed: $@" if $@;
                 return;
         }
 
         my %faked;
 
-        my $file = $class;
-        $file =~ s,::,/,g;
-        $file .= ".pm";
-
-        eval "require $class";
+        eval { require $file };
 
         while ($@ =~ /Can't locate (\S+)\.pm/) {
                 my $missing = $1;
@@ -4562,7 +4617,7 @@ sub maybe_require {
                 $missing =~ s,/,::,;
 
                 delete $INC{"$file"}; # so we can redo the require()
-                eval "require $class";
+                eval { require $file };
                 last unless $@;
         }
         die "require $class failed: $@" if $@;

--- a/lib/Smokeping/Examples.pm
+++ b/lib/Smokeping/Examples.pm
@@ -71,15 +71,15 @@ sub read_config_template {
 		probes => "",   # the Probes section, without the *** Probes *** line
 		targets => "",   # the Targets section, without the *** Targets *** line
 	};
-	open(F, "<$file") or die("open template configuration file $file for reading: $!");
+	open(my $cfg_fh, '<', $file) or die("open template configuration file $file for reading: $!");
 	my %found;
-	while (<F>) {
+	while (<$cfg_fh>) {
 		/\*\*\*\s*(Probes|Targets)\s*\*\*\*/ and $found{$1} = 1, next;
 		$h->{common}   .= $_ and next unless $found{Probes};
 		$h->{probes}   .= $_ and next unless $found{Targets};
 		$h->{targets}  .= $_;
 	}
-	close F;
+	close $cfg_fh;
 	return $h;
 }
 
@@ -185,9 +185,9 @@ sub writemanual {
 	my $text = shift;
 	my $filename = "smokeping_examples.pod";
 	print "\t$filename ...\n";
-	open(F, ">$filename") or die("open $filename for writing: $!");
-	print F $text;
-	close F;
+	open(my $out_fh, '>', $filename) or die("open $filename for writing: $!");
+	print $out_fh $text;
+	close $out_fh;
 }
 
 sub genpod {
@@ -212,8 +212,8 @@ sub writecfg {
 	my $file = shift;
 	my $template = shift;
 	my $h = shift;
-	open(F, ">$file") or die("open $file for writing: $!");
-	print F <<DOC;
+	open(my $out_fh, '>', $file) or die("open $file for writing: $!");
+	print $out_fh <<DOC;
 # This Smokeping example configuration file was automatically generated.
 #
 # Everything up to the Probes section is derived from a common template file.
@@ -222,17 +222,17 @@ sub writecfg {
 # This example is included in the smokeping_examples document.
 
 DOC
-	print F $template->{common};
-	print F "# (The actual example starts here.)\n";
-	print F "\n*** Probes ***\n\n";
-	print F join("\n", map { "# $_" } split(/\n/, $h->{probedoc} || 'No probedoc found!'));
-	print F "\n\n";
-	print F $h->{probes};
-	print F "\n*** Targets ***\n\n";
-	print F join("\n", map { "# $_" } split(/\n/, $h->{targetdoc} || 'No targetdoc found'));
-	print F "\n\n";
-	print F $h->{targets};
-	close F;
+	print $out_fh $template->{common};
+	print $out_fh "# (The actual example starts here.)\n";
+	print $out_fh "\n*** Probes ***\n\n";
+	print $out_fh join("\n", map { "# $_" } split(/\n/, $h->{probedoc} || 'No probedoc found!'));
+	print $out_fh "\n\n";
+	print $out_fh $h->{probes};
+	print $out_fh "\n*** Targets ***\n\n";
+	print $out_fh join("\n", map { "# $_" } split(/\n/, $h->{targetdoc} || 'No targetdoc found'));
+	print $out_fh "\n\n";
+	print $out_fh $h->{targets};
+	close $out_fh;
 }
 
 sub examples {

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -124,23 +124,23 @@ sub get_multi_detail ($$$$;$){
         $imgbase = $cfg->{General}{imgcache}."/".(join "/", @dirs)."/${file}";
         $imghref = $cfg->{General}{imgurl}."/".(join "/", @dirs)."/${file}";
         @tasks = @{$cfg->{Presentation}{detail}{_table}};
-        if (open (HG,"<${imgbase}.maxheight")){
-            while (<HG>){
+        if (open(my $hg_fh, '<', "${imgbase}.maxheight")){
+            while (<$hg_fh>){
                 chomp;
                 my @l = split / /;
                 $lastheight{$l[0]} = $l[1];
             }
-            close HG;
+            close $hg_fh;
         }
         for my $rrd (@hosts){
              my $newmax = Smokeping::findmax($cfg, $cfg->{General}{datadir}.$rrd.".rrd");
              map {$max->{$_} = $newmax->{$_} if not $max->{$_} or $newmax->{$_} > $max->{$_} } keys %{$newmax};
         }
-        if (open (HG,">${imgbase}.maxheight")){
+        if (open(my $hg_out, '>', "${imgbase}.maxheight")){
              foreach my $size (keys %{$max}){
-                 print HG "$size $max->{$size}\n";
+                 print $hg_out "$size $max->{$size}\n";
              }
-             close HG;
+             close $hg_out;
         }
     }
     elsif ($mode eq 'n' or $mode eq 'a') {
@@ -307,7 +307,7 @@ sub get_multi_detail ($$$$;$){
 
 
         if ($mode eq 'a'){ # ajax mode
-             open my $img, "${imgbase}_${end}_${start}.svg";
+             open(my $img, '<', "${imgbase}_${end}_${start}.svg");
              binmode $img;
              print "Content-Type: image/svg+xml\n";
              my $data;

--- a/lib/Smokeping/ciscoRttMonMIB.pm
+++ b/lib/Smokeping/ciscoRttMonMIB.pm
@@ -9,7 +9,7 @@ package Smokeping::ciscoRttMonMIB;
 
 require 5.004;
 
-use vars qw($VERSION);
+our $VERSION;
 use Exporter;
 
 use BER;

--- a/lib/Smokeping/matchers/Avgratio.pm
+++ b/lib/Smokeping/matchers/Avgratio.pm
@@ -83,7 +83,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 =cut
 
-use vars qw($VERSION);
+our $VERSION;
 
 
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/CheckLatency.pm
+++ b/lib/Smokeping/matchers/CheckLatency.pm
@@ -43,7 +43,7 @@ Dylan Vanderhoof <dylanv@semaphore.com>
 
 use strict;
 use base qw(Smokeping::matchers::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 use List::Util qw(min max);

--- a/lib/Smokeping/matchers/CheckLoss.pm
+++ b/lib/Smokeping/matchers/CheckLoss.pm
@@ -43,7 +43,7 @@ Dylan Vanderhoof <dylanv@semaphore.com>
 
 use strict;
 use base qw(Smokeping::matchers::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 use List::Util qw(min max);

--- a/lib/Smokeping/matchers/ConsecutiveLoss.pm
+++ b/lib/Smokeping/matchers/ConsecutiveLoss.pm
@@ -81,7 +81,7 @@ Based on the CheckLoss/Checklatency matchers by Dylan Vanderhoof 2006.
 
 use strict;
 use base qw(Smokeping::matchers::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 use List::Util qw(min max);

--- a/lib/Smokeping/matchers/ExpLoss.pm
+++ b/lib/Smokeping/matchers/ExpLoss.pm
@@ -63,7 +63,7 @@ Veniamin Konoplev E<lt>vkonoplev@acm.orgE<gt>
 
 use strict;
 use base qw(Smokeping::matchers::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/matchers/Median.pm
+++ b/lib/Smokeping/matchers/Median.pm
@@ -52,7 +52,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 use strict;
 use base qw(Smokeping::matchers::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/matchers/Medratio.pm
+++ b/lib/Smokeping/matchers/Medratio.pm
@@ -87,7 +87,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 =cut
 
-use vars qw($VERSION);
+our $VERSION;
 
 
 $VERSION = 1.0;

--- a/lib/Smokeping/matchers/base.pm
+++ b/lib/Smokeping/matchers/base.pm
@@ -19,7 +19,7 @@ Every matcher must provide the following methods:
 
 =cut
 
-use vars qw($VERSION);
+our $VERSION;
 use Carp;
 
 $VERSION = 1.0;

--- a/lib/Smokeping/pingMIB.pm
+++ b/lib/Smokeping/pingMIB.pm
@@ -10,7 +10,7 @@ package Smokeping::pingMIB;
 
 require 5.004;
 
-use vars qw($VERSION);
+our $VERSION;
 use Exporter;
 
 use BER;

--- a/lib/Smokeping/probes/AnotherCurl.pm
+++ b/lib/Smokeping/probes/AnotherCurl.pm
@@ -304,11 +304,11 @@ sub pingone {
 	my $count = $self->pings($t);
 
 	for (my $i = 0 ; $i < $count; $i++) {
-		open(P, "-|") or exec @cmd;
+		open(my $cmd_fh, '-|') or exec @cmd;
 
 		my $val;
 
-		while (<P>) {
+		while (<$cmd_fh>) {
 			chomp;
 			/^Total: (\d+\.\d+) DNS: (\d+\.\d+) Redirect: (\d+\.\d+) Connect: (\d+\.\d+) Appconnect: (\d+\.\d+) Pretransfert: (\d+\.\d+) Starttransfert: (\d+\.\d+)?/ and do {
 				# Total: time_total
@@ -334,7 +334,7 @@ sub pingone {
 				$self->do_debug("curl output: '$_', result: $val");
 			};
 		}
-		close P;
+		close $cmd_fh;
 		if ($?) {
 			my $status = $? >> 8;
 			my $signal = $? & 127;

--- a/lib/Smokeping/probes/Curl.pm
+++ b/lib/Smokeping/probes/Curl.pm
@@ -308,13 +308,13 @@ sub pingone {
 	my $count = $self->pings($t);
 
 	for (my $i = 0 ; $i < $count; $i++) {
-		open(P, "-|") or exec @cmd;
+		open(my $cmd_fh, '-|') or exec @cmd;
 
 		my $val;
 		my $expectOK = 1;
 		$expectOK = 0 if ($t->{vars}{expect} ne "");
 
-		while (<P>) {
+		while (<$cmd_fh>) {
 			chomp;
 			if (!$expectOK and index($_, $t->{vars}{expect}) != -1) {
 			    $expectOK = 1;
@@ -327,7 +327,7 @@ sub pingone {
 				$self->do_debug("curl output: '$_', result: $val");
 			};
 		}
-		close P;
+		close $cmd_fh;
 		if ($?) {
 			my $status = $? >> 8;
 			my $signal = $? & 127;

--- a/lib/Smokeping/probes/EchoPing.pm
+++ b/lib/Smokeping/probes/EchoPing.pm
@@ -179,15 +179,15 @@ sub pingone {
 
 	my @times;
 
-	open(P, "$cmd 2>&1 |") or carp("fork: $!");
+	open(my $cmd_fh, '-|', "$cmd 2>&1") or carp("fork: $!");
 
 	my @output;
-	while (<P>) {
+	while (<$cmd_fh>) {
 		chomp;
 		push @output, $_;
 		/^Elapsed time: (\d+\.\d+) seconds/ and push @times, $1;
 	}
-	close P;
+	close $cmd_fh;
 	if ($?) {
 		my $status = $? >> 8;
 		my $signal = $? & 127;

--- a/lib/Smokeping/probes/Radius.pm
+++ b/lib/Smokeping/probes/Radius.pm
@@ -86,9 +86,9 @@ sub new {
                         my $mode = $stat[2];
                         carp("Warning: secret file $self->{properties}{secretfile} is world-readable\n")
                                 if defined $mode and $mode & 04;
-			open(S, "<$self->{properties}{secretfile}")
+			open(my $secret_fh, '<', $self->{properties}{secretfile})
 				or croak("Error opening specified secret file $self->{properties}{secretfile}: $!");
-			while (<S>) {
+			while (<$secret_fh>) {
 				chomp;
 				next unless /\S/;
 				next if /^\s*#/;
@@ -97,7 +97,7 @@ sub new {
 					unless defined $host and defined $secret;
 				$self->secret($host, $secret);
 			}
-			close S;
+			close $secret_fh;
 	        }
 
 	}

--- a/lib/Smokeping/probes/TacacsPlus.pm
+++ b/lib/Smokeping/probes/TacacsPlus.pm
@@ -84,9 +84,9 @@ sub new {
                         my $mode = $stat[2];
                         carp("Warning: secret file $self->{properties}{secretfile} is world-readable\n")
                                 if defined $mode and $mode & 04;
-			open(S, "<$self->{properties}{secretfile}")
+			open(my $secret_fh, '<', $self->{properties}{secretfile})
 				or croak("Error opening specified secret file $self->{properties}{secretfile}: $!");
-			while (<S>) {
+			while (<$secret_fh>) {
 				chomp;
 				next unless /\S/;
 				next if /^\s*#/;
@@ -95,7 +95,7 @@ sub new {
 					unless defined $host and defined $secret;
 				$self->secret($host, $secret);
 			}
-			close S;
+			close $secret_fh;
 	        }
 
 	}

--- a/lib/Smokeping/probes/base.pm
+++ b/lib/Smokeping/probes/base.pm
@@ -14,7 +14,7 @@ to generate the POD document.
 
 =cut
 
-use vars qw($VERSION);
+our $VERSION;
 use Carp;
 use lib qw(..);
 use Smokeping;
@@ -169,19 +169,19 @@ sub addresses($)
         my $target = $self->{targets}{$tree};
         if ($target =~ m|/|) {
 	   my $dynbase = $self->target2dynfile($target);
-	   if ( open D, "<$dynbase.adr" ) {
+	   if ( open(my $adr_fh, '<', "$dynbase.adr") ) {
 	       my $ip;
-	       chomp($ip = <D>);
-	       close D;
+	       chomp($ip = <$adr_fh>);
+	       close $adr_fh;
 
-	       if ( open D, "<$dynbase.snmp" ) {
-		   my $snmp = <D>;
+	       if ( open(my $snmp_fh, '<', "$dynbase.snmp") ) {
+		   my $snmp = <$snmp_fh>;
 		   chomp($snmp);
 		   if ($snmp ne Smokeping::snmpget_ident $ip) {
 		       # something fishy snmp properties do not match, skip this address
 		       next;
 		   }
-                   close D;
+                   close $snmp_fh;
 	       }
 	       $target = $ip;
 	   } else {

--- a/lib/Smokeping/probes/passwordchecker.pm
+++ b/lib/Smokeping/probes/passwordchecker.pm
@@ -118,9 +118,9 @@ sub new {
 			carp("Warning: password file $self->{properties}{passwordfile} is world-readable\n")
 				if defined $mode and $mode & 04;
 
-			open(P, "<$self->{properties}{passwordfile}")
+			open(my $pw_fh, '<', $self->{properties}{passwordfile})
 				or croak("Error opening specified password file $self->{properties}{passwordfile}: $!");
-			while (<P>) {
+			while (<$pw_fh>) {
 				chomp;
 				next unless /\S/;
 				next if /^\s*#/;
@@ -128,7 +128,7 @@ sub new {
 				carp("Line $. in $self->{properties}{passwordfile} is invalid"), next unless defined $host and defined $username and defined $password;
 				$self->password($host, $username, $password);
 			}
-			close P;
+			close $pw_fh;
 	        }
 	}
 

--- a/lib/Smokeping/sorters/Loss.pm
+++ b/lib/Smokeping/sorters/Loss.pm
@@ -50,7 +50,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 use strict;
 use base qw(Smokeping::sorters::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/sorters/Max.pm
+++ b/lib/Smokeping/sorters/Max.pm
@@ -50,7 +50,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 use strict;
 use base qw(Smokeping::sorters::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/sorters/Median.pm
+++ b/lib/Smokeping/sorters/Median.pm
@@ -51,7 +51,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 use strict;
 use base qw(Smokeping::sorters::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/sorters/StdDev.pm
+++ b/lib/Smokeping/sorters/StdDev.pm
@@ -51,7 +51,7 @@ Tobias Oetiker <tobi@oetiker.ch>
 
 use strict;
 use base qw(Smokeping::sorters::base);
-use vars qw($VERSION);
+our $VERSION;
 $VERSION = 1.0;
 use Carp;
 

--- a/lib/Smokeping/sorters/base.pm
+++ b/lib/Smokeping/sorters/base.pm
@@ -34,7 +34,7 @@ Every sorter must provide the following methods:
 
 =cut
 
-use vars qw($VERSION);
+our $VERSION;
 use Carp;
 
 $VERSION = 1.0;


### PR DESCRIPTION
## Summary
- Replace `use vars qw(...)` with `our` declarations across all SmokePing modules
- Convert two-argument `open()` to three-argument form for safety
- Replace bareword filehandles (D, M, G, HG, PIDFILE, etc.) with lexical `my $fh` variables

25 files changed, 131 insertions(+), 131 deletions(-). Third-party bundled modules (SNMP_Session, SNMP_util, BER) left unchanged.

## Test plan
- [x] Container builds successfully
- [x] SmokePing starts and serves pages (HTTP 200)
- [ ] Verify probe functionality (fping, DNS)
- [ ] Verify dynamic host registration
- [ ] Verify alert email sending