### PR TITLE
feat: add smoke test harness

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Make
         run: make
 
+      - name: Check
+        run: make check
+
       - name: Dist
         run: make dist
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - add a smoke test harness covering module loads and the shipped config parser, wired into `make check` @Strykar
  - modernize web UI with updated CSS design system, SVG icons, sticky footer, and custom logo support via img/custom-logo.png @svenvg93
  - make FPingContinuous configuration more consistent with FPing by supporting protocol, interface and fwmark
 2026-03-31 10:48:53 +0200 Marc López <@MarcLopezB>

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@
 
 AUTOMAKE_OPTIONS =  foreign
 
-SUBDIRS = lib thirdparty bin doc etc htdocs
+SUBDIRS = lib thirdparty bin doc etc htdocs t
 
 EXTRA_DIST = COPYRIGHT CHANGES CONTRIBUTORS LICENSE cpanfile VERSION README.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ NOTES
    exit 1
 fi
 
-AC_CONFIG_FILES([Makefile bin/Makefile doc/Makefile htdocs/Makefile etc/Makefile lib/Makefile thirdparty/Makefile etc/config.dist])
+AC_CONFIG_FILES([Makefile bin/Makefile doc/Makefile htdocs/Makefile etc/Makefile lib/Makefile thirdparty/Makefile t/Makefile etc/config.dist])
 
 AC_SUBST(VERSION)
 

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,0 +1,5 @@
+Makefile
+Makefile.in
+*.log
+*.trs
+test-suite.log

--- a/t/00-load-core.t
+++ b/t/00-load-core.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+
+# Load every core SmokePing module.
+#
+# These are not optional. If one of them fails to load and the failure is
+# not "an external CPAN dep is missing", that is a regression.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use lib "$FindBin::Bin/../lib";
+use SPTest;
+
+my @core = qw(
+    Smokeping
+    Smokeping::Config
+    Smokeping::Master
+    Smokeping::Slave
+    Smokeping::Colorspace
+    Smokeping::RRDhelpers
+    Smokeping::RRDtools
+    Smokeping::Graphs
+    Smokeping::Examples
+    SNMP_Session
+    SNMP_util
+    BER
+);
+
+try_load($_) for @core;
+
+done_testing();

--- a/t/01-load-probes.t
+++ b/t/01-load-probes.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+
+# Load every probe module under lib/Smokeping/probes/.
+#
+# Many probes pull in optional CPAN modules (Authen::Radius, Net::LDAP,
+# Net::OpenSSH, ...); those count as skips when absent, not failures.
+# A failure here means an internal SmokePing symbol is broken.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use lib "$FindBin::Bin/../lib";
+use SPTest;
+
+my $probe_dir = "$FindBin::Bin/../lib/Smokeping/probes";
+my @probes;
+if (opendir(my $dh, $probe_dir)) {
+    @probes = sort grep { /\.pm$/ } readdir $dh;
+    closedir $dh;
+} else {
+    fail("cannot read $probe_dir: $!");
+}
+
+ok(@probes, "found probe modules in $probe_dir");
+
+for my $file (@probes) {
+    (my $mod = $file) =~ s/\.pm$//;
+    try_load("Smokeping::probes::$mod");
+}
+
+done_testing();

--- a/t/02-load-matchers.t
+++ b/t/02-load-matchers.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+# Load every matcher module under lib/Smokeping/matchers/.
+# Matchers have no external CPAN deps, so any failure here is real.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use lib "$FindBin::Bin/../lib";
+use SPTest;
+
+my $dir = "$FindBin::Bin/../lib/Smokeping/matchers";
+my @files;
+if (opendir(my $dh, $dir)) {
+    @files = sort grep { /\.pm$/ } readdir $dh;
+    closedir $dh;
+} else {
+    fail("cannot read $dir: $!");
+}
+
+ok(@files, "found matcher modules in $dir");
+
+for my $file (@files) {
+    (my $mod = $file) =~ s/\.pm$//;
+    try_load("Smokeping::matchers::$mod");
+}
+
+done_testing();

--- a/t/03-load-sorters.t
+++ b/t/03-load-sorters.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+# Load every sorter module under lib/Smokeping/sorters/.
+# Sorters have no external CPAN deps, so any failure here is real.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use lib "$FindBin::Bin/../lib";
+use SPTest;
+
+my $dir = "$FindBin::Bin/../lib/Smokeping/sorters";
+my @files;
+if (opendir(my $dh, $dir)) {
+    @files = sort grep { /\.pm$/ } readdir $dh;
+    closedir $dh;
+} else {
+    fail("cannot read $dir: $!");
+}
+
+ok(@files, "found sorter modules in $dir");
+
+for my $file (@files) {
+    (my $mod = $file) =~ s/\.pm$//;
+    try_load("Smokeping::sorters::$mod");
+}
+
+done_testing();

--- a/t/04-config-parse.t
+++ b/t/04-config-parse.t
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+
+# Parse the shipped sample config (etc/config.dist.in) through SmokePing's
+# real grammar. Catches regressions that break the parser or change the
+# shape of the top-level config tree.
+#
+# The config has @prefix@ / @SENDMAIL@ autoconf substitutions that we
+# resolve to in-tree paths so the test runs in a fresh checkout. Some
+# probes' validators check that referenced binaries exist (FPing checks
+# its 'binary' setting); SmokePing exposes $ENV{SERVER_SOFTWARE} as the
+# documented CGI-mode bypass for that, so we set it.
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use lib "$FindBin::Bin/../lib";
+
+use File::Temp ();
+use File::Spec;
+
+eval { require Smokeping; 1 }
+    or plan skip_all => "Smokeping core does not load: $@";
+
+my $repo = File::Spec->rel2abs("$FindBin::Bin/..");
+my $src  = "$repo/etc/config.dist.in";
+
+open(my $in, '<', $src) or BAIL_OUT("cannot read $src: $!");
+my $config = do { local $/; <$in> };
+close $in;
+
+# autoconf substitutions. @SENDMAIL@ is resolved from $PATH because
+# sendmail's path varies across distros; the parser doesn't validate
+# it today, and /bin/true is a safe no-op fallback if sendmail is absent.
+chomp(my $sendmail = qx{command -v sendmail 2>/dev/null});
+$sendmail ||= '/bin/true';
+$config =~ s/\@prefix\@/$repo/g;
+$config =~ s/\@SENDMAIL\@/$sendmail/g;
+
+# Directories the parser will resolve but not necessarily require to be
+# pre-populated. Create them under a tempdir to keep the source tree
+# untouched, and rewrite the relevant config keys to point there.
+my $tmpdir = File::Temp->newdir;
+for my $sub (qw(cache data var)) {
+    mkdir "$tmpdir/$sub" or BAIL_OUT("mkdir $tmpdir/$sub: $!");
+}
+$config =~ s{^(imgcache\s*=\s*).*$}{$1$tmpdir/cache}m;
+$config =~ s{^(datadir\s*=\s*).*$}{$1$tmpdir/data}m;
+$config =~ s{^(piddir\s*=\s*).*$}{$1$tmpdir/var}m;
+
+# Slaves' secrets file must be mode 0600 (parser refuses world-readable).
+# Copy the in-tree dist file to the tempdir and tighten perms.
+my $secrets = "$tmpdir/smokeping_secrets";
+open(my $sin,  '<', "$repo/etc/smokeping_secrets.dist") or BAIL_OUT($!);
+open(my $sout, '>', $secrets) or BAIL_OUT($!);
+print $sout do { local $/; <$sin> };
+close $sout;
+close $sin;
+chmod 0600, $secrets or BAIL_OUT("chmod $secrets: $!");
+$config =~ s{^(secrets\s*=\s*).*$}{$1$secrets}m;
+
+my ($fh, $cfgfile) = File::Temp::tempfile('smokeping-test-XXXXXX',
+    SUFFIX => '.cfg', UNLINK => 1, TMPDIR => 1);
+print $fh $config;
+close $fh;
+
+# Bypass the "binary must exist" validators in probes that wrap external
+# tools. This is the same escape hatch SmokePing uses in CGI mode.
+local $ENV{SERVER_SOFTWARE} = 'smokeping-test';
+
+my $parser = Smokeping::get_parser();
+ok($parser, 'Smokeping::get_parser returned a parser')
+    or BAIL_OUT("no parser, cannot continue");
+
+my $cfg = $parser->parse($cfgfile);
+ok($cfg, 'sample config parses without error')
+    or diag("parser error: " . ($parser->{err} // '(unknown)'));
+
+if ($cfg) {
+    for my $section (qw(General Database Presentation Probes Targets Alerts Slaves)) {
+        ok(exists $cfg->{$section}, "parsed config has '$section' section");
+    }
+    # Round-trip checks: the parser produced non-empty values for
+    # representative scalar keys. We avoid asserting specific strings so
+    # an editorial change to etc/config.dist.in does not break the test.
+    like($cfg->{General}{owner}, qr/\S/,
+        "General/owner has a value");
+    like($cfg->{Probes}{FPing}{binary}, qr/\S/,
+        "Probes/FPing/binary has a value");
+}
+
+done_testing();

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,0 +1,28 @@
+# Copyright (C) 2026 Avinash Duduskar
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+AUTOMAKE_OPTIONS = foreign
+
+TESTS = \
+    00-load-core.t \
+    01-load-probes.t \
+    02-load-matchers.t \
+    03-load-sorters.t \
+    04-config-parse.t
+
+# Tests run as executable Perl scripts via their shebang. PERL5LIB points
+# at the in-tree library and at the Carton-installed CPAN deps under
+# thirdparty/, so `make check` works after `make` has populated either.
+TESTS_ENVIRONMENT = \
+    PERL5LIB="$(abs_top_srcdir)/lib:$(abs_top_srcdir)/thirdparty/lib/perl5:$$PERL5LIB"
+
+EXTRA_DIST = $(TESTS) lib/SPTest.pm

--- a/t/lib/SPTest.pm
+++ b/t/lib/SPTest.pm
@@ -1,0 +1,64 @@
+package SPTest;
+
+# Copyright (C) 2026 Avinash Duduskar
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# Shared helpers for the SmokePing test suite.
+#
+# try_load($module) attempts to require $module and emits one test result:
+#   * pass  - module loaded successfully
+#   * skip  - module load failed because an external CPAN dep is missing
+#             (the test environment does not have the optional dependency)
+#   * fail  - module load failed for any other reason: syntax error,
+#             missing internal SmokePing module, undefined sub at compile
+#             time, etc.
+#
+# The skip-vs-fail split is what makes this useful: a contributor running
+# the suite without every CPAN dep installed sees skips, not noise, while
+# a regression that breaks internal symbols still produces a real failure.
+
+use strict;
+use warnings;
+use Test::More;
+use Exporter 'import';
+
+our @EXPORT = qw(try_load);
+
+sub try_load {
+    my ($mod) = @_;
+    my $rc = eval "require $mod; 1";
+    my $err = $@;
+
+    if ($rc) {
+        pass("load $mod");
+        return 1;
+    }
+
+    chomp(my $first_line = (split /\n/, ($err // ''))[0] // '');
+
+    if ($err && $err =~ /Can't locate (\S+?)\.pm in \@INC/) {
+        my $missing = $1;
+        $missing =~ s{/}{::}g;
+        unless ($missing =~ /^(Smokeping|SNMP_Session|SNMP_util|BER)\b/) {
+            Test::More->builder->skip(
+                "$mod requires $missing (not installed)"
+            );
+            return 1;
+        }
+    }
+
+    fail("load $mod");
+    diag("error loading $mod: $first_line");
+    return 0;
+}
+
+1;


### PR DESCRIPTION
Addresses part of #468.

@Zugschlus' #468 asks for the test suite to ship in release tarballs so
Debian QA can verify equivalence between the released tarball and the
git tag. Master has no `t/` directory today, so this lays one down with
`EXTRA_DIST = $(TESTS) lib/SPTest.pm` so the tests ride along with
`make dist`. (The other half of #468, byte-identical `git archive <tag>`
vs the release tarball, is out of scope for this patch.)

#483 (closed by @moetiker, "approaching changes differently") proposed a
~1300-line unit-test suite. This is a deliberately smaller scope:

- `t/00-load-core.t`: every core SmokePing module loads
- `t/01-load-probes.t` / `02-load-matchers.t` / `03-load-sorters.t`:
  every probe/matcher/sorter loads
- `t/04-config-parse.t`: `etc/config.dist.in` parses through the real
  grammar, with `@prefix@` and `@SENDMAIL@` resolved at test time and
  the documented `SERVER_SOFTWARE` escape hatch used to bypass probe
  binary checks

A shared `SPTest.pm` distinguishes "missing optional CPAN dep" (skip)
from "internal SmokePing symbol broken" (fail), so a contributor without
every probe's CPAN dep installed still gets a clean run for the parts
that should work. `@SENDMAIL@` is resolved from `$PATH` rather than
hardcoded so the test runs on minimal containers regardless of where
sendmail lives.

CI: `build-test.yaml` runs `make check` after `make`, before `make dist`.

Tested via `prove t/` (86 pass), `./configure && make && make check`
(5/5 PASS, 0 FAIL), and `make dist` (tarball includes `t/`).