### PR TITLE
Remove tests on $RRDs::VERSION because version comparison is unreliable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+ - drop old rrd version check, incompatible with rrdtool 1.10 and later versioning @rosario
  - add a smoke test harness covering module loads and the shipped config parser, wired into `make check` @Strykar
  - modernize web UI with updated CSS design system, SVG icons, sticky footer, and custom logo support via img/custom-logo.png @svenvg93
  - make FPingContinuous configuration more consistent with FPing by supporting protocol, interface and fwmark

--- a/lib/Smokeping.pm
+++ b/lib/Smokeping.pm
@@ -876,9 +876,7 @@ sub get_overview ($$$$){
         POSIX::strftime($cfg->{Presentation}{overview}{strftime},
                         localtime(time)) : scalar localtime(time);
 
-    if ( $RRDs::VERSION >= 1.199908 ){
-            $date =~ s|:|\\:|g;
-    }
+    $date =~ s|:|\\:|g;
     foreach my $prop (sort {exists $tree->{$a}{_order} ? ($tree->{$a}{_order} <=> $tree->{$b}{_order}) : ($a cmp $b)}
                       grep {  ref $tree->{$_} eq 'HASH' and not /^__/ }
                       keys %$tree) {
@@ -1341,11 +1339,8 @@ sub get_detail ($$$$;$){
                 );
     }
 
-    my $BS = '';
-    if ( $RRDs::VERSION >= 1.199908 ){
-        $ProbeDesc =~ s|:|\\:|g;
-        $BS = '\\';
-    }
+    $ProbeDesc =~ s|:|\\:|g;
+    my $BS = '\\';
 
     for (@tasks) {
         my ($desc,$start,$end) = @{$_};
@@ -1354,9 +1349,7 @@ sub get_detail ($$$$;$){
         my $sigtime = ($end and $end =~ /^\d+$/) ? $end : time;
         my $date = $cfg->{Presentation}{detail}{strftime} ?
                    POSIX::strftime($cfg->{Presentation}{detail}{strftime}, localtime($sigtime)) : scalar localtime($sigtime);
-        if ( $RRDs::VERSION >= 1.199908 ){
-            $date =~ s|:|\\:|g;
-        }
+        $date =~ s|:|\\:|g;
         $end ||= 'last';
         $start = exp2seconds($start) if $mode =~ /[s]/;
 

--- a/lib/Smokeping/Graphs.pm
+++ b/lib/Smokeping/Graphs.pm
@@ -198,9 +198,7 @@ sub get_multi_detail ($$$$;$){
         my $sigtime = ($end and $end =~ /^\d+$/) ? $end : time;
         my $date = $cfg->{Presentation}{detail}{strftime} ?
                    POSIX::strftime($cfg->{Presentation}{detail}{strftime}, localtime($sigtime)) : scalar localtime($sigtime);
-        if ( $RRDs::VERSION >= 1.199908 ){
-            $date =~ s|:|\\:|g;
-        }
+        $date =~ s|:|\\:|g;
         $end ||= 'last';
         $start = Smokeping::exp2seconds($start) if $mode =~ /[s]/;
 


### PR DESCRIPTION
$RRDs::VERSION does not reliably reflect the rrdtool release version and numeric comparisons can produce incorrect results. For example:

 rrdtool release   $RRDs::VERSION   numeric value   >= 1.199908?
  1.9.0             1.8000           1.8             true  (escaped)
  1.10.0–1.10.3     1.10000/1.10003  1.1             false (not escaped)

This causes newer releases to fail the version check due to Perl's numeric version handling. Remove the tests relying on $RRDs::VERSION instead of depending on this unreliable comparison and because no one is supposed to still using a rrdtool released before 1999.